### PR TITLE
Support for OnlyNotifyWithAttributes

### DIFF
--- a/PropertyChanged.Fody/CecilExtensions.cs
+++ b/PropertyChanged.Fody/CecilExtensions.cs
@@ -168,6 +168,8 @@ public static class CecilExtensions
         return attributes.Any(attribute => attribute.Constructor.DeclaringType.FullName == attributeName);
     }
 
+    public static IEnumerable<string> Names(this IEnumerable<CustomAttribute> attributes) => attributes.Select(a => a.Constructor.DeclaringType.FullName);
+
     public static IEnumerable<TypeReference> GetAllInterfaces(this TypeDefinition type)
     {
         while (type != null)

--- a/PropertyChanged.Fody/CecilExtensions.cs
+++ b/PropertyChanged.Fody/CecilExtensions.cs
@@ -168,6 +168,7 @@ public static class CecilExtensions
         return attributes.Any(attribute => attribute.Constructor.DeclaringType.FullName == attributeName);
     }
 
+    /// <summary>Returns full type names for custom <paramref name="attributes"/>.</summary>
     public static IEnumerable<string> Names(this IEnumerable<CustomAttribute> attributes) => attributes.Select(a => a.Constructor.DeclaringType.FullName);
 
     public static IEnumerable<TypeReference> GetAllInterfaces(this TypeDefinition type)

--- a/PropertyChanged.Fody/ModuleWeaver.cs
+++ b/PropertyChanged.Fody/ModuleWeaver.cs
@@ -26,6 +26,7 @@ public partial class ModuleWeaver: BaseModuleWeaver
         DetectIlGeneratedByDependency();
         ProcessDependsOnAttributes();
         WalkPropertyData();
+        ProcessNoOwnNotify();
         CheckForWarnings();
         ProcessOnChangedMethods();
         CheckForStackOverflow();

--- a/PropertyChanged.Fody/NoOwnNotifyProcessing.cs
+++ b/PropertyChanged.Fody/NoOwnNotifyProcessing.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public partial class ModuleWeaver
+{
+    HashSet<string> OnlyNotifyWithAttributes;
+
+    void ProcessNoOwnNotify()
+    {
+        var value = Config?.Attributes("OnlyNotifyWithAttributes").Select(x => x.Value).SingleOrDefault();
+        if (value != null)
+            OnlyNotifyWithAttributes = new HashSet<string>(value.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()));
+
+        ProcessNoOwnNotify(NotifyNodes);
+    }
+
+    void ProcessNoOwnNotify(IEnumerable<TypeNode> nodes)
+    {
+        foreach (var typeNode in nodes)
+        {
+            foreach (var property in typeNode.TypeDefinition.Properties)
+            {
+                if (OnlyNotifyWithAttributes != null && !OnlyNotifyWithAttributes.Overlaps(property.CustomAttributes.Names()))
+                    typeNode.NoOwnNotifyProperties.Add(property);
+            }
+            ProcessNoOwnNotify(typeNode.Nodes);
+        }
+    }
+}

--- a/PropertyChanged.Fody/NoOwnNotifyProcessing.cs
+++ b/PropertyChanged.Fody/NoOwnNotifyProcessing.cs
@@ -4,27 +4,32 @@ using System.Linq;
 
 public partial class ModuleWeaver
 {
-    HashSet<string> OnlyNotifyWithAttributes;
-
+    /// <summary>
+    /// Processes all type nodes and fills <see cref="TypeNode.NoOwnNotifyProperties"/> with properties which shouldn't be notified using configuration rules.
+    /// If `OnlyNotifyWithAttributes="attr_type_name1,attr_type_name2"` set in the config then all properties without one of listed attributes will be added to NoOwnNotifyProperties and won't emit PropertyChanged event.
+    /// </summary>
     void ProcessNoOwnNotify()
     {
-        var value = Config?.Attributes("OnlyNotifyWithAttributes").Select(x => x.Value).SingleOrDefault();
+        HashSet<string> onlyNotifyWithAttributes = null;                                                   // set of full attribute names for which PropertyChanged event should be emitted, if empty then no filtering applied
+        var value = Config?.Attributes("OnlyNotifyWithAttributes").Select(x => x.Value).SingleOrDefault(); // check XML config for OnlyNotifyWithAttributes attribute in form of `attr_type_name1,attr_type_name2` (type name with namespace)
         if (value != null)
-            OnlyNotifyWithAttributes = new HashSet<string>(value.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()));
+            onlyNotifyWithAttributes = new HashSet<string>(value.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()));
 
-        ProcessNoOwnNotify(NotifyNodes);
+        if (onlyNotifyWithAttributes == null || onlyNotifyWithAttributes.Count == 0) return;               // skip processing if there no attributes specified
+        ProcessNoOwnNotify(NotifyNodes, onlyNotifyWithAttributes);                                         // go recursively through all type nodes and fill NoOwnNotifyProperties
     }
 
-    void ProcessNoOwnNotify(IEnumerable<TypeNode> nodes)
+    /// <summary>Processes all type nodes and fills <see cref="TypeNode.NoOwnNotifyProperties"/> with properties which doesn't have one of attributes from <paramref name="onlyNotifyWithAttributes"/> set.</summary>
+    void ProcessNoOwnNotify(IEnumerable<TypeNode> nodes, HashSet<string> onlyNotifyWithAttributes)
     {
         foreach (var typeNode in nodes)
         {
-            foreach (var property in typeNode.TypeDefinition.Properties)
+            foreach (var property in typeNode.TypeDefinition.Properties)                                   // go through type properties
             {
-                if (OnlyNotifyWithAttributes != null && !OnlyNotifyWithAttributes.Overlaps(property.CustomAttributes.Names()))
-                    typeNode.NoOwnNotifyProperties.Add(property);
+                if (!onlyNotifyWithAttributes.Overlaps(property.CustomAttributes.Names()))                 // check if at least one of custom attributes is in the list
+                    typeNode.NoOwnNotifyProperties.Add(property);                                          // if not so then add property to NoOwnNotifyProperties
             }
-            ProcessNoOwnNotify(typeNode.Nodes);
+            ProcessNoOwnNotify(typeNode.Nodes, onlyNotifyWithAttributes);                                  // call recursively for nested type nodes
         }
     }
 }

--- a/PropertyChanged.Fody/OnChangedWalker.cs
+++ b/PropertyChanged.Fody/OnChangedWalker.cs
@@ -217,8 +217,7 @@ public partial class ModuleWeaver
 
         bool PropertyWillBeNotified(PropertyDefinition p)
         {
-            return notifyNode.PropertyDatas
-                .Any(pd => pd.PropertyDefinition == p || pd.AlsoNotifyFor.Contains(p));
+            return notifyNode.PropertyDatas.ContainsKey(p) || notifyNode.PropertyDatas.Values.Any(pd => pd.AlsoNotifyFor.Contains(p));
         }
 
         if (onChangedMethod.Properties.Any(PropertyWillBeNotified))

--- a/PropertyChanged.Fody/PropertyDataWalker.cs
+++ b/PropertyChanged.Fody/PropertyDataWalker.cs
@@ -46,7 +46,7 @@ public partial class ModuleWeaver
             {
                 return;
             }
-            node.PropertyDatas.Add(new PropertyData
+            node.PropertyDatas.Add(propertyDefinition, new PropertyData
             {
                 ParentType = node,
                 BackingFieldReference = backingFieldReference,
@@ -64,7 +64,7 @@ public partial class ModuleWeaver
 Looked for 'PropertyChanged', 'propertyChanged', '_PropertyChanged' and '_propertyChanged'.
 The most likely cause is that you have implemented a custom event accessor for the PropertyChanged event and have called the PropertyChangedEventHandler something stupid.");
         }
-        node.PropertyDatas.Add(new PropertyData
+        node.PropertyDatas.Add(propertyDefinition, new PropertyData
         {
             ParentType = node,
             BackingFieldReference = backingFieldReference,

--- a/PropertyChanged.Fody/PropertyWeaver.cs
+++ b/PropertyChanged.Fody/PropertyWeaver.cs
@@ -143,6 +143,9 @@ public class PropertyWeaver
     int AddEventInvokeCall(int index, List<OnChangedMethod> onChangedMethods, PropertyDefinition property)
     {
         index = AddOnChangedMethodCalls(index, onChangedMethods, property);
+        if (propertyData.ParentType.NoOwnNotifyProperties.Contains(property))
+            return index;
+
         if (propertyData.AlreadyNotifies.Contains(property.Name))
         {
             moduleWeaver.WriteDebug($"\t\t\t{property.Name} skipped since call already exists");

--- a/PropertyChanged.Fody/StackOverflowChecker.cs
+++ b/PropertyChanged.Fody/StackOverflowChecker.cs
@@ -10,20 +10,20 @@ public partial class ModuleWeaver
     {
         foreach (var node in notifyNodes)
         {
-            foreach (var propertyData in node.PropertyDatas)
+            foreach (var propertyDefinition in node.PropertyDatas.Keys)
             {
                 if (node.EventInvoker.InvokerType != InvokerTypes.BeforeAfter)
                 {
                     continue;
                 }
-                if (CheckIfGetterCallsSetter(propertyData.PropertyDefinition))
+                if (CheckIfGetterCallsSetter(propertyDefinition))
                 {
-                    throw new WeavingException($"{propertyData.PropertyDefinition.GetName()} Getter calls setter which will cause a stack overflow as the setter uses the getter for obtaining the before and after values.");
+                    throw new WeavingException($"{propertyDefinition.GetName()} Getter calls setter which will cause a stack overflow as the setter uses the getter for obtaining the before and after values.");
                 }
 
-                if (CheckIfGetterCallsVirtualBaseSetter(propertyData.PropertyDefinition))
+                if (CheckIfGetterCallsVirtualBaseSetter(propertyDefinition))
                 {
-                    throw new WeavingException($"{propertyData.PropertyDefinition.GetName()} Getter of calls virtual setter of base class which will cause a stack overflow as the setter uses the getter for obtaining the before and after values.");
+                    throw new WeavingException($"{propertyDefinition.GetName()} Getter of calls virtual setter of base class which will cause a stack overflow as the setter uses the getter for obtaining the before and after values.");
                 }
             }
 

--- a/PropertyChanged.Fody/TypeEqualityFinder.cs
+++ b/PropertyChanged.Fody/TypeEqualityFinder.cs
@@ -28,7 +28,7 @@ public partial class ModuleWeaver
 
     void FindComparisonMethods(TypeNode node)
     {
-        foreach (var data in node.PropertyDatas)
+        foreach (var data in node.PropertyDatas.Values)
         {
             data.EqualsMethod = FindTypeEquality(data);
         }

--- a/PropertyChanged.Fody/TypeNode.cs
+++ b/PropertyChanged.Fody/TypeNode.cs
@@ -10,6 +10,7 @@ public class TypeNode
         PropertyDependencies = new List<PropertyDependency>();
         Mappings = new List<MemberMapping>();
         PropertyDatas = new Dictionary<PropertyDefinition, PropertyData>();
+        NoOwnNotifyProperties = new HashSet<PropertyDefinition>();
     }
 
     public TypeDefinition TypeDefinition;
@@ -21,5 +22,6 @@ public class TypeNode
     public Dictionary<PropertyDefinition, PropertyData> PropertyDatas;
     public List<PropertyDefinition> AllProperties;
     public ICollection<OnChangedMethod> OnChangedMethods;
+    public HashSet<PropertyDefinition> NoOwnNotifyProperties; // these properties won't emit PropertyChanged event, but still may notify dependent properties or invoke on change methods
     public IEnumerable<PropertyDefinition> DeclaredProperties => AllProperties.Where(prop => prop.DeclaringType == TypeDefinition);
 }

--- a/PropertyChanged.Fody/TypeNode.cs
+++ b/PropertyChanged.Fody/TypeNode.cs
@@ -9,7 +9,7 @@ public class TypeNode
         Nodes = new List<TypeNode>();
         PropertyDependencies = new List<PropertyDependency>();
         Mappings = new List<MemberMapping>();
-        PropertyDatas = new List<PropertyData>();
+        PropertyDatas = new Dictionary<PropertyDefinition, PropertyData>();
     }
 
     public TypeDefinition TypeDefinition;
@@ -18,7 +18,7 @@ public class TypeNode
     public List<MemberMapping> Mappings;
     public EventInvokerMethod EventInvoker;
     public MethodReference IsChangedInvoker;
-    public List<PropertyData> PropertyDatas;
+    public Dictionary<PropertyDefinition, PropertyData> PropertyDatas;
     public List<PropertyDefinition> AllProperties;
     public ICollection<OnChangedMethod> OnChangedMethods;
     public IEnumerable<PropertyDefinition> DeclaredProperties => AllProperties.Where(prop => prop.DeclaringType == TypeDefinition);

--- a/PropertyChanged.Fody/TypeProcessor.cs
+++ b/PropertyChanged.Fody/TypeProcessor.cs
@@ -19,7 +19,7 @@ public partial class ModuleWeaver
 
             WriteDebug("\t" + node.TypeDefinition.FullName);
 
-            foreach (var propertyData in node.PropertyDatas)
+            foreach (var propertyData in node.PropertyDatas.Values)
             {
                 var body = propertyData.PropertyDefinition.SetMethod.Body;
 

--- a/PropertyChanged.Fody/WarningChecker.cs
+++ b/PropertyChanged.Fody/WarningChecker.cs
@@ -9,13 +9,13 @@ public partial class ModuleWeaver
     {
         foreach (var node in notifyNodes)
         {
-            foreach (var propertyData in node.PropertyDatas.ToList())
+            foreach (var propertyData in node.PropertyDatas.Values.ToList())
             {
                 var warning = CheckForWarning(propertyData, node.EventInvoker.InvokerType);
                 if (warning != null)
                 {
                     EmitConditionalWarning(propertyData.PropertyDefinition, $"{propertyData.PropertyDefinition.GetName()} {warning} Property will be ignored.");
-                    node.PropertyDatas.Remove(propertyData);
+                    node.PropertyDatas.Remove(propertyData.PropertyDefinition);
                 }
             }
             CheckForWarnings(node.Nodes);

--- a/PropertyChanged.sln
+++ b/PropertyChanged.sln
@@ -62,6 +62,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyWithInheritance", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyWithExternalInheritance", "TestAssemblies\AssemblyWithExternalInheritance\AssemblyWithExternalInheritance.csproj", "{10BDE166-0BFC-41D9-9326-805717A054B3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyWithPropertyAttributes", "TestAssemblies\AssemblyWithPropertyAttributes\AssemblyWithPropertyAttributes.csproj", "{AE0D0B20-5F4C-48BA-A0DB-C00F2A70D146}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -308,6 +310,18 @@ Global
 		{10BDE166-0BFC-41D9-9326-805717A054B3}.Release|ARM.Build.0 = Release|Any CPU
 		{10BDE166-0BFC-41D9-9326-805717A054B3}.Release|x86.ActiveCfg = Release|Any CPU
 		{10BDE166-0BFC-41D9-9326-805717A054B3}.Release|x86.Build.0 = Release|Any CPU
+		{AE0D0B20-5F4C-48BA-A0DB-C00F2A70D146}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AE0D0B20-5F4C-48BA-A0DB-C00F2A70D146}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AE0D0B20-5F4C-48BA-A0DB-C00F2A70D146}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{AE0D0B20-5F4C-48BA-A0DB-C00F2A70D146}.Debug|ARM.Build.0 = Debug|Any CPU
+		{AE0D0B20-5F4C-48BA-A0DB-C00F2A70D146}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AE0D0B20-5F4C-48BA-A0DB-C00F2A70D146}.Debug|x86.Build.0 = Debug|Any CPU
+		{AE0D0B20-5F4C-48BA-A0DB-C00F2A70D146}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AE0D0B20-5F4C-48BA-A0DB-C00F2A70D146}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AE0D0B20-5F4C-48BA-A0DB-C00F2A70D146}.Release|ARM.ActiveCfg = Release|Any CPU
+		{AE0D0B20-5F4C-48BA-A0DB-C00F2A70D146}.Release|ARM.Build.0 = Release|Any CPU
+		{AE0D0B20-5F4C-48BA-A0DB-C00F2A70D146}.Release|x86.ActiveCfg = Release|Any CPU
+		{AE0D0B20-5F4C-48BA-A0DB-C00F2A70D146}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -333,6 +347,7 @@ Global
 		{89CC72A8-43A9-4593-9FA5-61091C989B40} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
 		{9D3B5C35-6523-45D9-B11D-0FBB67C0866A} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
 		{10BDE166-0BFC-41D9-9326-805717A054B3} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
+		{AE0D0B20-5F4C-48BA-A0DB-C00F2A70D146} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {ABD5CA78-3690-4D62-8642-3463D9FAE144}

--- a/PropertyChanged.sln.DotSettings
+++ b/PropertyChanged.sln.DotSettings
@@ -4,6 +4,7 @@
 	<s:Boolean x:Key="/Default/CodeEditing/Intellisense/CodeCompletion/IntelliSenseCompletingCharacters/IntelliSenseCompletingCharactersSettingCSharp/UpgradedFromVSSettings/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeEditing/Intellisense/LookupWindow/ShowSummary/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeEditing/Localization/CSharpLocalizationOptions/DontAnalyseVerbatimStrings/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/CodeAnnotations/NamespacesWithAnnotations/=AssemblyWithPropertyAttributes_002EAnnotations/@EntryIndexedValue">True</s:Boolean>
 	
 	<s:Boolean x:Key="/Default/CodeInspection/ExcludedFiles/FileMasksToSkip/=_002A_002A_005C_002APackages_005C_002A_002A_005C_002A_002E_002A/@EntryIndexedValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/AnalysisEnabled/@EntryValue">SOLUTION</s:String>

--- a/TestAssemblies/AssemblyWithPropertyAttributes/AssemblyWithPropertyAttributes.csproj
+++ b/TestAssemblies/AssemblyWithPropertyAttributes/AssemblyWithPropertyAttributes.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net48;net6</TargetFrameworks>
+    <NoWarn>0067</NoWarn>
+    <DisableFody>true</DisableFody>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\PropertyChanged\PropertyChanged.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TestAssemblies/AssemblyWithPropertyAttributes/ClassWithAttributedProperties.cs
+++ b/TestAssemblies/AssemblyWithPropertyAttributes/ClassWithAttributedProperties.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using PropertyChanged;
 
+/// <summary>Test class for processors working with property attributes (i.e. NoOwnNotifyProcessing).</summary>
 public class ClassWithAttributedProperties : INotifyPropertyChanged
 {
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/TestAssemblies/AssemblyWithPropertyAttributes/ClassWithAttributedProperties.cs
+++ b/TestAssemblies/AssemblyWithPropertyAttributes/ClassWithAttributedProperties.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using PropertyChanged;
+
+public class ClassWithAttributedProperties : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public List<string> Notifications = new List<string>();
+
+    [DisplayName] public string? DisplayName { get; set; }
+    [Description] public string? Description { get; set; }
+    [AlsoNotifyFor(nameof(DisplayName))] public string? NoOwnNotify { get; set; }
+
+    public ClassWithAttributedProperties() => PropertyChanged += (_, args) => Notifications.Add($"event:{args.PropertyName}");
+
+    public void OnNoOwnNotifyChanged() => Notifications.Add("method:NoOwnNotify");
+}

--- a/Tests/CheckForNoOwnNotifyPropertiesTests.cs
+++ b/Tests/CheckForNoOwnNotifyPropertiesTests.cs
@@ -1,0 +1,26 @@
+namespace Tests;
+
+using System.Collections.Generic;
+using System.Xml.Linq;
+using Fody;
+using Xunit;
+
+public class NoOwnNotifyProcessingTests
+{
+    [Theory]
+    [InlineData("System.ComponentModel.DisplayNameAttribute", new[] { "event:DisplayName", "event:DisplayName", "method:NoOwnNotify" })]
+    [InlineData("System.ComponentModel.DescriptionAttribute", new[] { "event:Description", "method:NoOwnNotify" })]
+    [InlineData("System.ComponentModel.DisplayNameAttribute,System.ComponentModel.DescriptionAttribute", new[] { "event:DisplayName", "event:Description", "event:DisplayName", "method:NoOwnNotify" })]
+    public void OnlyNotifiesPropertiesWithDisplayNameAttribute(string onlyNotifyWithAttributes, string[] expectedNotifications)
+    {
+        var xElement = XElement.Parse($"<PropertyChanged OnlyNotifyWithAttributes='{onlyNotifyWithAttributes}'/>");
+        var moduleWeaver = new ModuleWeaver { Config = xElement };
+        var testResult = moduleWeaver.ExecuteTestRun("AssemblyWithPropertyAttributes.dll");
+        var instance = testResult.GetInstance("ClassWithAttributedProperties");
+        instance.DisplayName = "My Name";
+        instance.Description = "My Description";
+        instance.NoOwnNotify = "Value";
+        var notifications = (List<string>)instance.Notifications;
+        Assert.Equal(expectedNotifications, notifications);
+    }
+}

--- a/Tests/CheckForNoOwnNotifyPropertiesTests.cs
+++ b/Tests/CheckForNoOwnNotifyPropertiesTests.cs
@@ -1,5 +1,3 @@
-namespace Tests;
-
 using System.Collections.Generic;
 using System.Xml.Linq;
 using Fody;

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -33,5 +33,6 @@
     <ProjectReference Include="..\TestAssemblies\AssemblyWithStaticOnPropertyNameChanged\AssemblyWithStaticOnPropertyNameChanged.csproj" />
     <ProjectReference Include="..\TestAssemblies\AssemblyWithTypeFilter\AssemblyWithTypeFilter.csproj" />
     <ProjectReference Include="..\TestAssemblies\AssemblyWithInheritance\AssemblyWithInheritance.csproj" />
+    <ProjectReference Include="..\TestAssemblies\AssemblyWithPropertyAttributes\AssemblyWithPropertyAttributes.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Added support for explicit specifying properties which should emit PropertyChanged event with custom attributes.
If config has OnlyNotifyWithAttributes with comma separate list of full attribute names like:
```xml
<PropertyChanged OnlyNotifyWithAttributes="System.ComponentModel.DisplayNameAttribute,System.ComponentModel.DescriptionAttribute"/>
```
then only these properties will be weaved for OnPropertyChanged invocation. 
Unlike [DoNotNotify] properties without attribute will still behave same for all other aspects: triggering dependent properties and calling `On_PropertyName_Changed` methods.

Related issue: https://app.clickup.com/t/10591183/ECO-17508