### PR TITLE
Auto implement INotifyPropertyChangedInvoker interface

### DIFF
--- a/PropertyChanged.Fody/CecilExtensions.cs
+++ b/PropertyChanged.Fody/CecilExtensions.cs
@@ -171,6 +171,15 @@ public static class CecilExtensions
     /// <summary>Returns full type names for custom <paramref name="attributes"/>.</summary>
     public static IEnumerable<string> Names(this IEnumerable<CustomAttribute> attributes) => attributes.Select(a => a.Constructor.DeclaringType.FullName);
 
+    /// <summary>Returns full names for <paramref name="members"/>.</summary>
+    public static IEnumerable<string> FullNames(this IEnumerable<MemberReference> members) => members.Select(a => a.FullName);
+
+    /// <summary>Checks if <paramref name="type"/> has the <paramref name="interface"/>.</summary>
+    public static bool HasInterface(this TypeDefinition type, TypeReference @interface) => type.GetAllInterfaces().FullNames().Contains(@interface.FullName);
+
+    /// <summary>Returns <see cref="AssemblyNameReference"/> by <paramref name="assemblyName"/> like "PropertyChanged".</summary>
+    public static AssemblyNameReference GetAssemblyReference(this ModuleDefinition moduleDefinition, string assemblyName) => moduleDefinition.AssemblyReferences.SingleOrDefault(x => x.Name == assemblyName);
+
     public static IEnumerable<TypeReference> GetAllInterfaces(this TypeDefinition type)
     {
         while (type != null)

--- a/PropertyChanged.Fody/CecilUtils.cs
+++ b/PropertyChanged.Fody/CecilUtils.cs
@@ -1,0 +1,19 @@
+using Mono.Cecil;
+
+public static class CecilUtils
+{
+    /// <summary>Makes <see cref="TypeReference"/> from <paramref name="assemblyQualifiedName"/> like "System.Int32, System.Runtime".</summary>
+    public static TypeReference MakeTypeReference(string assemblyQualifiedName)
+    {
+        var assemblySplitIndex = assemblyQualifiedName.IndexOf(',');
+        var assemblyReference = AssemblyNameReference.Parse(assemblyQualifiedName.Substring(assemblySplitIndex + 1).TrimStart());
+        return MakeTypeReference(assemblyQualifiedName.Substring(0, assemblySplitIndex), assemblyReference);
+    }
+
+    /// <summary>Makes <see cref="TypeReference"/> from <paramref name="fullTypeName"/> like "System.Int32" declared in <paramref name="assemblyReference"/>.</summary>
+    public static TypeReference MakeTypeReference(string fullTypeName, AssemblyNameReference assemblyReference)
+    {
+        var namespaceSplitIndex = fullTypeName.LastIndexOf('.');
+        return new TypeReference(fullTypeName.Substring(0, namespaceSplitIndex), fullTypeName.Substring(namespaceSplitIndex + 1), null, assemblyReference);
+    }
+}

--- a/PropertyChanged.Fody/Config/AddPropertyChangedInvokerConfig.cs
+++ b/PropertyChanged.Fody/Config/AddPropertyChangedInvokerConfig.cs
@@ -3,12 +3,12 @@ using System.Xml;
 
 public partial class ModuleWeaver
 {
-    public bool AddPropertyChangedInvoker = false;
+    public bool AddPropertyChangedInvoker;
 
     public void ResolveAddPropertyChangedInvokerConfig()
     {
         var value = Config?.Attributes("AddPropertyChangedInvoker").Select(a => a.Value).SingleOrDefault();
         if (value != null)
-            CheckForEquality = XmlConvert.ToBoolean(value.ToLowerInvariant());
+            AddPropertyChangedInvoker = XmlConvert.ToBoolean(value.ToLowerInvariant());
     }
 }

--- a/PropertyChanged.Fody/Config/AddPropertyChangedInvokerConfig.cs
+++ b/PropertyChanged.Fody/Config/AddPropertyChangedInvokerConfig.cs
@@ -1,0 +1,14 @@
+using System.Linq;
+using System.Xml;
+
+public partial class ModuleWeaver
+{
+    public bool AddPropertyChangedInvoker = false;
+
+    public void ResolveAddPropertyChangedInvokerConfig()
+    {
+        var value = Config?.Attributes("AddPropertyChangedInvoker").Select(a => a.Value).SingleOrDefault();
+        if (value != null)
+            CheckForEquality = XmlConvert.ToBoolean(value.ToLowerInvariant());
+    }
+}

--- a/PropertyChanged.Fody/MethodInjector.cs
+++ b/PropertyChanged.Fody/MethodInjector.cs
@@ -105,7 +105,25 @@ public partial class ModuleWeaver
         }
 
         invokerType = InvokerTypes.PropertyChangedArg;
-        return InjectEventArgsMethod(targetType, propertyChangedField);
+        return AddPropertyChangedInvoker ? FindInvokePropertyChangedRecursively(targetType) : InjectEventArgsMethod(targetType, propertyChangedField); // if AddPropertyChangedInvoker set then reuse implementation of INotifyPropertyChangedInvoker.InvokePropertyChanged
+    }
+
+    /// <summary>Find recursively <c>InvokePropertyChanged</c> in <paramref name="targetType"/> or in it's base types.</summary>
+    MethodDefinition FindInvokePropertyChangedRecursively(TypeDefinition targetType)
+    {
+        var type = targetType;
+        do
+        {
+            foreach (var method in type.Methods)
+            {
+                if (method.Name == "InvokePropertyChanged" && method.Parameters.Count == 1 && method.Parameters[0].ParameterType.FullName == PropertyChangedEventArgsReference.FullName)
+                    return method;
+            }
+
+            type = type.BaseType?.Resolve();
+        } while (type != null);
+
+        throw new WeavingException($"Can't find InvokePropertyChanged for {targetType.FullName}");
     }
 
     MethodDefinition InjectFsharp(TypeDefinition targetType, FieldDefinition fsharpEvent)

--- a/PropertyChanged.Fody/MethodInjector.cs
+++ b/PropertyChanged.Fody/MethodInjector.cs
@@ -15,11 +15,9 @@ public partial class ModuleWeaver
                 throw new WeavingException(message);
             }
 
-            var methodDefinition = GetMethodDefinition(targetType, out _);
-
             return new EventInvokerMethod
             {
-                MethodReference = InjectInterceptedMethod(targetType, methodDefinition).GetGeneric(),
+                MethodReference = InjectInterceptedMethod(targetType).GetGeneric(),
                 InvokerType = InterceptorType,
                 IsVisibleFromChildren = true
             };

--- a/PropertyChanged.Fody/MethodInterceptorInjector.cs
+++ b/PropertyChanged.Fody/MethodInterceptorInjector.cs
@@ -1,11 +1,20 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 
 public partial class ModuleWeaver
 {
-    MethodDefinition InjectInterceptedMethod(TypeDefinition targetType, MethodDefinition innerOnPropertyChanged)
+    /// <summary>Injects OnPropertyChanged with interceptor. Depending on <see cref="InterceptorUsesInvoker"/> value will use either <see cref="InjectInterceptedMethodWithInvoker"/> or <see cref="InjectInterceptedMethodWithDelegate"/>.</summary>
+    MethodDefinition InjectInterceptedMethod(TypeDefinition targetType) => InterceptorUsesInvoker ? InjectInterceptedMethodWithInvoker(targetType) : InjectInterceptedMethodWithDelegate(targetType);
+
+    /// <summary>
+    /// Standard Fody.PropertyChanged approach where invocation of inner property changed wrapped in Action and passed to Interceptor.
+    /// Depending on interceptor type generates either <c>Intercept(this, () => InnerOnPropertyChanged(propertyName), propertyName)</c> or <c>Intercept(this, () => InnerOnPropertyChanged(propertyName), propertyName, before, after)</c>.
+    /// </summary>
+    MethodDefinition InjectInterceptedMethodWithDelegate(TypeDefinition targetType)
     {
+        var innerOnPropertyChanged = GetMethodDefinition(targetType, out _);
         var delegateHolderInjector = new DelegateHolderInjector
                                      {
                                          TargetTypeDefinition = targetType,
@@ -65,6 +74,40 @@ public partial class ModuleWeaver
 
         instructions.Add(last);
         method.Body.InitLocals = true;
+
+        targetType.Methods.Add(method);
+        return method;
+    }
+
+    /// <summary>
+    /// Call to interceptor with INotifyPropertyChangedInvoker argument instead of a source object and callback Action.
+    /// Depending on interceptor type generates either <c>Intercept((INotifyPropertyChangedInvoker)this, propertyName)</c> or <c>Intercept((INotifyPropertyChangedInvoker)this, propertyName, before, after)</c>.
+    /// </summary>
+    MethodDefinition InjectInterceptedMethodWithInvoker(TypeDefinition targetType)
+    {
+        var method = new MethodDefinition(EventInvokerNames.First(), GetMethodAttributes(targetType), TypeSystem.VoidReference);
+
+        var propertyName = new ParameterDefinition("propertyName", ParameterAttributes.None, TypeSystem.StringReference);
+        var parameters = method.Parameters;
+        parameters.Add(propertyName);
+        if (InterceptorType == InvokerTypes.BeforeAfter)
+        {
+            var before = new ParameterDefinition("before", ParameterAttributes.None, TypeSystem.ObjectReference);
+            parameters.Add(before);
+            var after = new ParameterDefinition("after", ParameterAttributes.None, TypeSystem.ObjectReference);
+            parameters.Add(after);
+        }
+
+        var instructions = method.Body.Instructions;                              // PropertyChangedNotificationInterceptor.Intercept(
+        instructions.Add(Instruction.Create(OpCodes.Ldarg_0));                    //   this,
+        instructions.Add(Instruction.Create(OpCodes.Ldarg_1));                    //   propertyName
+        if (InterceptorType == InvokerTypes.BeforeAfter)
+        {
+            instructions.Add(Instruction.Create(OpCodes.Ldarg_2));                //   ,before
+            instructions.Add(Instruction.Create(OpCodes.Ldarg_3));                //   ,after
+        }
+        instructions.Add(Instruction.Create(OpCodes.Call, InterceptMethod));      // )
+        instructions.Add(Instruction.Create(OpCodes.Ret));
 
         targetType.Methods.Add(method);
         return method;

--- a/PropertyChanged.Fody/ModuleWeaver.cs
+++ b/PropertyChanged.Fody/ModuleWeaver.cs
@@ -20,8 +20,8 @@ public partial class ModuleWeaver: BaseModuleWeaver
         BuildTypeNodes();
         CleanDoNotNotifyTypes();
         CleanCodeGenedTypes();
-        FindMethodsForNodes();
         ProcessPropertyChangedInvoker();
+        FindMethodsForNodes();
         FindIsChangedMethod();
         FindAllProperties();
         FindMappings();

--- a/PropertyChanged.Fody/ModuleWeaver.cs
+++ b/PropertyChanged.Fody/ModuleWeaver.cs
@@ -13,6 +13,7 @@ public partial class ModuleWeaver: BaseModuleWeaver
         ResolveSuppressWarningsConfig();
         ResolveSuppressOnPropertyNameChangedWarningConfig();
         ResolveEventInvokerName();
+        ResolveAddPropertyChangedInvokerConfig();
         FindCoreReferences();
         FindInterceptor();
         ProcessFilterTypeAttributes();
@@ -20,6 +21,7 @@ public partial class ModuleWeaver: BaseModuleWeaver
         CleanDoNotNotifyTypes();
         CleanCodeGenedTypes();
         FindMethodsForNodes();
+        ProcessPropertyChangedInvoker();
         FindIsChangedMethod();
         FindAllProperties();
         FindMappings();

--- a/PropertyChanged.Fody/PropertyChangedInvokerProcessing.cs
+++ b/PropertyChanged.Fody/PropertyChangedInvokerProcessing.cs
@@ -3,8 +3,8 @@ using Mono.Cecil.Cil;
 
 public partial class ModuleWeaver
 {
-    /// <summary>Returns <see cref="MethodReference"/> to <c>PropertyChanged.INotifyPropertyChangedInvoker.InvokePropertyChanged</c> if config option 'AddPropertyChangedInvoker' set to true in Fody.PropertyChanged config.</summary>
-    MethodReference GetInvokePropertyChangedMethod()
+    /// <summary>Imports <see cref="MethodReference"/> for <c>PropertyChanged.INotifyPropertyChangedInvoker.InvokePropertyChanged</c> if config option 'AddPropertyChangedInvoker' set to true in Fody.PropertyChanged config.</summary>
+    MethodReference ImportInvokePropertyChangedInterfaceMethodReference()
     {
         var manualNotifyInterface = CecilUtils.MakeTypeReference("PropertyChanged.INotifyPropertyChangedInvoker", ModuleDefinition.GetAssemblyReference("PropertyChanged")); // make type reference for interface
         var invokePropertyChangedMethod = new MethodReference("InvokePropertyChanged", TypeSystem.VoidReference, manualNotifyInterface);                                     // make method reference for InvokePropertyChanged
@@ -16,7 +16,7 @@ public partial class ModuleWeaver
     void ProcessPropertyChangedInvoker()
     {
         if (!AddPropertyChangedInvoker) return;
-        var invokePropertyChangedMethod = GetInvokePropertyChangedMethod();
+        var invokePropertyChangedMethod = ImportInvokePropertyChangedInterfaceMethodReference();
         foreach (var typeNode in NotifyNodes)                                                             // go through all base nodes implementing IPropertyChanged
         {
             var type = typeNode.TypeDefinition;

--- a/PropertyChanged.Fody/PropertyChangedInvokerProcessing.cs
+++ b/PropertyChanged.Fody/PropertyChangedInvokerProcessing.cs
@@ -1,0 +1,65 @@
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+public partial class ModuleWeaver
+{
+    /// <summary>Returns <see cref="MethodReference"/> to <c>PropertyChanged.INotifyPropertyChangedInvoker.InvokePropertyChanged</c> if config option 'AddPropertyChangedInvoker' set to true in Fody.PropertyChanged config.</summary>
+    MethodReference GetInvokePropertyChangedMethod()
+    {
+        var manualNotifyInterface = CecilUtils.MakeTypeReference("PropertyChanged.INotifyPropertyChangedInvoker", ModuleDefinition.GetAssemblyReference("PropertyChanged")); // make type reference for interface
+        var invokePropertyChangedMethod = new MethodReference("InvokePropertyChanged", TypeSystem.VoidReference, manualNotifyInterface);                                     // make method reference for InvokePropertyChanged
+        invokePropertyChangedMethod.Parameters.Add(new ParameterDefinition("eventArgs", ParameterAttributes.None, PropertyChangedEventArgsReference));                       // add PropertyChangedEventArgs parameter
+        return ModuleDefinition.ImportReference(invokePropertyChangedMethod);                                                                                                // import for the current module
+    }
+
+    /// <summary>Processes <see cref="NotifyNodes"/> for <c>INotifyPropertyChangedInvoker</c> auto-implementation if config option 'AddPropertyChangedInvoker' set to true in Fody.PropertyChanged config..</summary>
+    void ProcessPropertyChangedInvoker()
+    {
+        if (!AddPropertyChangedInvoker) return;
+        var invokePropertyChangedMethod = GetInvokePropertyChangedMethod();
+        foreach (var typeNode in NotifyNodes)                                                             // go through all base nodes implementing IPropertyChanged
+        {
+            var type = typeNode.TypeDefinition;
+            var eventHandlerField = GetEventHandlerField(type);
+            if (eventHandlerField == null) continue;                                                      // skip types with custom PropertyChanged implementation
+
+            var interfaceMethod = invokePropertyChangedMethod;
+            var interfaceType = interfaceMethod.DeclaringType;
+            if (!type.HasInterface(interfaceType))                                                        // skip if the type already implements INotifyPropertyChangedInvoker
+            {
+                type.Interfaces.Add(new InterfaceImplementation(interfaceType));                          // add the interface to the type
+                type.Methods.Add(CreateEventInvokerMethod(interfaceMethod, eventHandlerField));           // add InvokePropertyChanged method implementation to the type
+            }
+        }
+    }
+
+    /// <summary>Creates InvokePropertyChanged method implementation as <c>[GeneratedCode] void InvokePropertyChanged(PropertyChangedEventArgs args) => this.PropertyChanged?.Invoke(this, args);</c>.</summary>
+    MethodDefinition CreateEventInvokerMethod(MethodReference interfaceMethod, FieldReference propertyChangedField)
+    {
+        var method = new MethodDefinition(interfaceMethod.Name, MethodAttributes.Public | MethodAttributes.Final | MethodAttributes.Virtual | MethodAttributes.HideBySig | MethodAttributes.NewSlot, interfaceMethod.ReturnType);
+        method.Parameters.Add(new ParameterDefinition("eventArgs", ParameterAttributes.None, PropertyChangedEventArgsReference));
+        MarkAsGeneratedCode(method.CustomAttributes); // add [GeneratedCode]
+
+        var handlerVariable = new VariableDefinition(PropChangedHandlerReference);                                  // PropertyChangedEventHandler handler;
+        method.Body.Variables.Add(handlerVariable);
+
+        var instructions = method.Body.Instructions;
+
+        var last = Instruction.Create(OpCodes.Ret);
+        instructions.Add(Instruction.Create(OpCodes.Ldarg_0));
+        instructions.Add(Instruction.Create(OpCodes.Ldfld, propertyChangedField));                                  // handler = this.PropertyChanged;
+        instructions.Add(Instruction.Create(OpCodes.Stloc_0));
+        instructions.Add(Instruction.Create(OpCodes.Ldloc_0));
+        instructions.Add(Instruction.Create(OpCodes.Brfalse_S, last));                                              // if (handler == null) return;
+        instructions.Add(Instruction.Create(OpCodes.Ldloc_0));
+        instructions.Add(Instruction.Create(OpCodes.Ldarg_0));
+        instructions.Add(Instruction.Create(OpCodes.Ldarg_1));
+        instructions.Add(Instruction.Create(OpCodes.Tail));
+        instructions.Add(Instruction.Create(OpCodes.Callvirt, PropertyChangedEventHandlerInvokeReference));         // handler.Invoke(this, args);
+
+        instructions.Add(last);
+        method.Body.InitLocals = true;
+        return method;
+    }
+
+}

--- a/PropertyChanged.sln
+++ b/PropertyChanged.sln
@@ -64,6 +64,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyWithExternalInherit
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyWithPropertyAttributes", "TestAssemblies\AssemblyWithPropertyAttributes\AssemblyWithPropertyAttributes.csproj", "{AE0D0B20-5F4C-48BA-A0DB-C00F2A70D146}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyWithInvokerInterceptor", "TestAssemblies\AssemblyWithInvokerInterceptor\AssemblyWithInvokerInterceptor.csproj", "{4933F02F-72B1-48CC-B721-9C67BE72DD80}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyWithInvokerBeforeAfterInterceptor", "TestAssemblies\AssemblyWithInvokerBeforeAfterInterceptor\AssemblyWithInvokerBeforeAfterInterceptor.csproj", "{1102ED10-7E36-4C30-A116-7A053387CB3D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -322,6 +326,30 @@ Global
 		{AE0D0B20-5F4C-48BA-A0DB-C00F2A70D146}.Release|ARM.Build.0 = Release|Any CPU
 		{AE0D0B20-5F4C-48BA-A0DB-C00F2A70D146}.Release|x86.ActiveCfg = Release|Any CPU
 		{AE0D0B20-5F4C-48BA-A0DB-C00F2A70D146}.Release|x86.Build.0 = Release|Any CPU
+		{4933F02F-72B1-48CC-B721-9C67BE72DD80}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4933F02F-72B1-48CC-B721-9C67BE72DD80}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4933F02F-72B1-48CC-B721-9C67BE72DD80}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{4933F02F-72B1-48CC-B721-9C67BE72DD80}.Debug|ARM.Build.0 = Debug|Any CPU
+		{4933F02F-72B1-48CC-B721-9C67BE72DD80}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4933F02F-72B1-48CC-B721-9C67BE72DD80}.Debug|x86.Build.0 = Debug|Any CPU
+		{4933F02F-72B1-48CC-B721-9C67BE72DD80}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4933F02F-72B1-48CC-B721-9C67BE72DD80}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4933F02F-72B1-48CC-B721-9C67BE72DD80}.Release|ARM.ActiveCfg = Release|Any CPU
+		{4933F02F-72B1-48CC-B721-9C67BE72DD80}.Release|ARM.Build.0 = Release|Any CPU
+		{4933F02F-72B1-48CC-B721-9C67BE72DD80}.Release|x86.ActiveCfg = Release|Any CPU
+		{4933F02F-72B1-48CC-B721-9C67BE72DD80}.Release|x86.Build.0 = Release|Any CPU
+		{1102ED10-7E36-4C30-A116-7A053387CB3D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1102ED10-7E36-4C30-A116-7A053387CB3D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1102ED10-7E36-4C30-A116-7A053387CB3D}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{1102ED10-7E36-4C30-A116-7A053387CB3D}.Debug|ARM.Build.0 = Debug|Any CPU
+		{1102ED10-7E36-4C30-A116-7A053387CB3D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1102ED10-7E36-4C30-A116-7A053387CB3D}.Debug|x86.Build.0 = Debug|Any CPU
+		{1102ED10-7E36-4C30-A116-7A053387CB3D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1102ED10-7E36-4C30-A116-7A053387CB3D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1102ED10-7E36-4C30-A116-7A053387CB3D}.Release|ARM.ActiveCfg = Release|Any CPU
+		{1102ED10-7E36-4C30-A116-7A053387CB3D}.Release|ARM.Build.0 = Release|Any CPU
+		{1102ED10-7E36-4C30-A116-7A053387CB3D}.Release|x86.ActiveCfg = Release|Any CPU
+		{1102ED10-7E36-4C30-A116-7A053387CB3D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -348,6 +376,8 @@ Global
 		{9D3B5C35-6523-45D9-B11D-0FBB67C0866A} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
 		{10BDE166-0BFC-41D9-9326-805717A054B3} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
 		{AE0D0B20-5F4C-48BA-A0DB-C00F2A70D146} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
+		{4933F02F-72B1-48CC-B721-9C67BE72DD80} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
+		{1102ED10-7E36-4C30-A116-7A053387CB3D} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {ABD5CA78-3690-4D62-8642-3463D9FAE144}

--- a/PropertyChanged/INotifyPropertyChangedInvoker.cs
+++ b/PropertyChanged/INotifyPropertyChangedInvoker.cs
@@ -1,0 +1,10 @@
+namespace PropertyChanged;
+
+using System.ComponentModel;
+
+/// <summary>Allows to invoke PropertyChanged by external code. Auto-implemented by Fody if `AddPropertyChangedInvoker="true"` in XML config.</summary>
+public interface INotifyPropertyChangedInvoker
+{
+    /// <summary>Invokes <c>PropertyChanged?.Invoke(args)</c>.</summary>
+    void InvokePropertyChanged(PropertyChangedEventArgs args);
+}

--- a/TestAssemblies/AssemblyWithInvokerBeforeAfterInterceptor/AssemblyWithInvokerBeforeAfterInterceptor.csproj
+++ b/TestAssemblies/AssemblyWithInvokerBeforeAfterInterceptor/AssemblyWithInvokerBeforeAfterInterceptor.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+  <PropertyGroup>
+    <TargetFrameworks>net48;net6</TargetFrameworks>
+    <NoWarn>0067</NoWarn>
+    <DisableFody>true</DisableFody>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../PropertyChanged/PropertyChanged.csproj" />
+  </ItemGroup>
+</Project>

--- a/TestAssemblies/AssemblyWithInvokerBeforeAfterInterceptor/ClassToTest.cs
+++ b/TestAssemblies/AssemblyWithInvokerBeforeAfterInterceptor/ClassToTest.cs
@@ -1,0 +1,9 @@
+﻿using System.ComponentModel;
+
+public class ClassToTest :
+    INotifyPropertyChanged
+{
+    public string Property1 { get; set; }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+}

--- a/TestAssemblies/AssemblyWithInvokerBeforeAfterInterceptor/PropertyNotificationInterceptor.cs
+++ b/TestAssemblies/AssemblyWithInvokerBeforeAfterInterceptor/PropertyNotificationInterceptor.cs
@@ -1,0 +1,13 @@
+﻿using System.ComponentModel;
+using PropertyChanged;
+
+public static class PropertyChangedNotificationInterceptor
+{
+    public static void Intercept(INotifyPropertyChangedInvoker invoker, string propertyName, object before, object after)
+    {
+        invoker.InvokePropertyChanged(new PropertyChangedEventArgs(propertyName));
+        InterceptCalled = true;
+    }
+
+    public static bool InterceptCalled { get; set; }
+}

--- a/TestAssemblies/AssemblyWithInvokerInterceptor/AssemblyWithInvokerInterceptor.csproj
+++ b/TestAssemblies/AssemblyWithInvokerInterceptor/AssemblyWithInvokerInterceptor.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+  <PropertyGroup>
+    <TargetFrameworks>net48;net6</TargetFrameworks>
+    <NoWarn>0067</NoWarn>
+    <DisableFody>true</DisableFody>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="../../PropertyChanged/PropertyChanged.csproj" />
+  </ItemGroup>
+</Project>

--- a/TestAssemblies/AssemblyWithInvokerInterceptor/ClassToTest.cs
+++ b/TestAssemblies/AssemblyWithInvokerInterceptor/ClassToTest.cs
@@ -1,0 +1,9 @@
+﻿using System.ComponentModel;
+
+public class ClassToTest :
+    INotifyPropertyChanged
+{
+    public string Property1 { get; set; }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+}

--- a/TestAssemblies/AssemblyWithInvokerInterceptor/PropertyNotificationInterceptor.cs
+++ b/TestAssemblies/AssemblyWithInvokerInterceptor/PropertyNotificationInterceptor.cs
@@ -1,0 +1,13 @@
+﻿using System.ComponentModel;
+using PropertyChanged;
+
+public static class PropertyChangedNotificationInterceptor
+{
+    public static void Intercept(INotifyPropertyChangedInvoker invoker, string propertyName)
+    {
+        invoker.InvokePropertyChanged(new PropertyChangedEventArgs(propertyName));
+        InterceptCalled = true;
+    }
+
+    public static bool InterceptCalled { get; set; }
+}

--- a/Tests/AssemblyToProcessTests.cs
+++ b/Tests/AssemblyToProcessTests.cs
@@ -10,6 +10,7 @@ using Mono.Cecil.Cil;
 using Xunit;
 using Xunit.Abstractions;
 
+[Collection("AssemblyToProcess")]
 public class AssemblyToProcessTests
 {
     readonly ITestOutputHelper outputHelper;

--- a/Tests/AssemblyWithInvokerInterceptorTests.cs
+++ b/Tests/AssemblyWithInvokerInterceptorTests.cs
@@ -1,0 +1,39 @@
+﻿using System.Reflection;
+using Fody;
+using Xunit;
+
+public class AssemblyWithInvokerInterceptorTests
+{
+    [Fact]
+    public void Simple()
+    {
+        var weavingTask = new ModuleWeaver { AddPropertyChangedInvoker = true };
+        var testResult = weavingTask.ExecuteTestRun(
+            "AssemblyWithInvokerInterceptor.dll",
+            ignoreCodes: new[] {"0x80131869"});
+
+        var assembly = testResult.Assembly;
+        var instance = assembly.GetInstance("ClassToTest");
+        EventTester.TestProperty(instance, false);
+        var type = assembly.GetType("PropertyChangedNotificationInterceptor");
+        var propertyInfo = type.GetProperty("InterceptCalled", BindingFlags.Static | BindingFlags.Public)!;
+        var value = (bool)propertyInfo.GetValue(null, null);
+        Assert.True(value);
+    }
+
+    [Fact]
+    public void BeforeAfter()
+    {
+        var weavingTask = new ModuleWeaver { AddPropertyChangedInvoker = true };
+        var testResult = weavingTask.ExecuteTestRun(
+            "AssemblyWithInvokerBeforeAfterInterceptor.dll",
+            ignoreCodes: new[] {"0x80131869"});
+        var assembly = testResult.Assembly;
+        var instance = assembly.GetInstance("ClassToTest");
+        EventTester.TestProperty(instance, false);
+        var type = assembly.GetType("PropertyChangedNotificationInterceptor");
+        var propertyInfo = type.GetProperty("InterceptCalled", BindingFlags.Static | BindingFlags.Public)!;
+        var value = (bool)propertyInfo.GetValue(null, null);
+        Assert.True(value);
+    }
+}

--- a/Tests/PropertyChangedInvokerProcessingTests.cs
+++ b/Tests/PropertyChangedInvokerProcessingTests.cs
@@ -1,0 +1,41 @@
+using System.ComponentModel;
+using Fody;
+using PropertyChanged;
+using Xunit;
+
+[Collection("AssemblyToProcess")]
+public class PropertyChangedInvokerProcessingTests
+{
+    [Fact]
+    public void ShouldImplementINotifyPropertyChangedInvokerInterfaceWhenConfigEnabled()
+    {
+        var weaver = new ModuleWeaver { AddPropertyChangedInvoker = true };
+        var testResult = weaver.ExecuteTestRun("AssemblyToProcess.dll");
+        var instance = testResult.GetInstance("ClassParentWithProperty");
+        Assert.True(instance is INotifyPropertyChangedInvoker);
+        Assert.False(testResult.GetInstance("ReactiveUI.ReactiveObject") is INotifyPropertyChangedInvoker, "Shouldn't auto-implement for classes with custom PropertyChanged implementation.");
+
+        string notifiedPropertyName = null;
+        object notifiedObject = null;
+
+        void Handler(object source, PropertyChangedEventArgs args)
+        {
+            notifiedObject = source;
+            notifiedPropertyName = args.PropertyName;
+        }
+
+        ((INotifyPropertyChanged)instance).PropertyChanged += Handler;
+        instance.InvokePropertyChanged(new PropertyChangedEventArgs("Foo"));
+        Assert.Equal((object)instance, notifiedObject);
+        Assert.Equal("Foo", notifiedPropertyName);
+    }
+
+    [Fact]
+    public void ShouldNotImplementINotifyPropertyChangedInvokerInterfaceByDefault()
+    {
+        var weaver = new ModuleWeaver();
+        var testResult = weaver.ExecuteTestRun("AssemblyToProcess.dll");
+        var instance = testResult.GetInstance("ClassParentWithProperty");
+        Assert.False(instance is INotifyPropertyChangedInvoker);
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -28,6 +28,8 @@
     <ProjectReference Include="..\TestAssemblies\AssemblyWithDisabledTriggerDependentProperties\AssemblyWithDisabledTriggerDependentProperties.csproj" />
     <ProjectReference Include="..\TestAssemblies\AssemblyWithExternalInheritance\AssemblyWithExternalInheritance.csproj" />
     <ProjectReference Include="..\TestAssemblies\AssemblyWithInterceptor\AssemblyWithInterceptor.csproj" />
+    <ProjectReference Include="..\TestAssemblies\AssemblyWithInvokerInterceptor\AssemblyWithInvokerInterceptor.csproj" />
+    <ProjectReference Include="..\TestAssemblies\AssemblyWithInvokerBeforeAfterInterceptor\AssemblyWithInvokerBeforeAfterInterceptor.csproj" />
     <ProjectReference Include="..\TestAssemblies\AssemblyWithNonVoidOnPropertyNameChanged\AssemblyWithNonVoidOnPropertyNameChanged.csproj" />
     <ProjectReference Include="..\TestAssemblies\AssemblyWithStackOverflow\AssemblyWithStackOverflow.csproj" />
     <ProjectReference Include="..\TestAssemblies\AssemblyWithStaticOnPropertyNameChanged\AssemblyWithStaticOnPropertyNameChanged.csproj" />


### PR DESCRIPTION
Added config option AddPropertyChangedInvoker. When enabled all INotifyPropertyChanged types with default PropertyChanged will implement INotifyPropertyChangedInvoker interface. With the interface you can invoke PropertyChanged event via InvokePropertyChanged interface method.

```xml
<StrangeLoopGames.PropertyChanged AddPropertyChangedInvoker="true" />
```

Source
```c#
public ABC : INotifyPropertyChanged
{
    public event PropertyChanged;   
}
```

Generated

```csharp
public class ABC : INotifyPropertyChanged, INotifyPropertyChangedInvoker
{
    public event PropertyChanged;   
	
    [GeneratedCode] public void InvokePropertyChanged(PropertyChangedEventArgs args) => PropertyChanged?.Invoke(this, args);
}
```

Also if `AddPropertyChangedInvoker` enabled then you can use `Intercept` method with `INotifyPropertyChangedInvoker` instead of `Action` callback.

```csharp
public static class PropertyChangedNotificationInterceptor
{
    public static void Intercept(INotifyPropertyChangedInvoker invoker, string propertyName) => invoker.InvokePropertyChanged(new PropertyChangedEventArgs(propertyName));
}
```

or 

```csharp
public static class PropertyChangedNotificationInterceptor
{
    public static void Intercept(INotifyPropertyChangedInvoker invoker, string propertyName, object before, object after) => invoker.InvokePropertyChanged(new PropertyChangedEventArgs(propertyName));
}
```