### PR TITLE
DisabledBeforeAfterForReadOnlyProperties support

### DIFF
--- a/PropertyChanged.Fody/Config/DisableBeforeAfterForReadOnlyPropertiesConfig.cs
+++ b/PropertyChanged.Fody/Config/DisableBeforeAfterForReadOnlyPropertiesConfig.cs
@@ -1,0 +1,24 @@
+using System.Linq;
+using System.Xml;
+
+public partial class ModuleWeaver
+{
+    /// <summary>
+    /// When value set then before/after values for read-only properties won't be calculated, but instead callback will be invoked with default values.
+    /// It is useful when calculated properties may fail when object not fully initialized during deserialization or creation and you really don't care about these calculated properties changes, but aware about settable properties only.
+    /// Readonly properties may restore default behavior with help of [ForceBeforeAfter] attribute. In that case real before/after values always submitted no matter of setting value.
+    /// </summary>
+    public bool DisableBeforeAfterForReadOnlyProperties;
+
+    /// <summary>Resolves value for <see cref="DisableBeforeAfterForReadOnlyProperties"/> from XML config.</summary>
+    public void ResolveDisableBeforeAfterForReadOnlyPropertiesConfig()
+    {
+        var value = Config?.Attributes("DisableBeforeAfterForReadOnlyProperties")
+            .Select(a => a.Value)
+            .SingleOrDefault();
+        if (value != null)
+        {
+            DisableBeforeAfterForReadOnlyProperties = XmlConvert.ToBoolean(value.ToLowerInvariant());
+        }
+    }
+}

--- a/PropertyChanged.Fody/PropertyWeaver.cs
+++ b/PropertyChanged.Fody/PropertyWeaver.cs
@@ -155,12 +155,12 @@ public class PropertyWeaver
         moduleWeaver.WriteDebug($"\t\t\t{property.Name}");
         if (typeNode.EventInvoker.InvokerType == InvokerTypes.BeforeAfterGeneric)
         {
-            return AddBeforeAfterGenericInvokerCall(index, property);
+            return AddBeforeAfterInvokerCall(index, property, property.PropertyType);
         }
 
         if (typeNode.EventInvoker.InvokerType == InvokerTypes.BeforeAfter)
         {
-            return AddBeforeAfterInvokerCall(index, property);
+            return AddBeforeAfterInvokerCall(index, property, typeSystem.ObjectReference);
         }
 
         if (typeNode.EventInvoker.InvokerType == InvokerTypes.PropertyChangedArg)
@@ -253,31 +253,11 @@ public class PropertyWeaver
         return instructions.Insert(index, CallEventInvoker(property).ToArray());
     }
 
-    int AddBeforeAfterGenericInvokerCall(int index, PropertyDefinition property)
+    int AddBeforeAfterInvokerCall(int index, PropertyDefinition property, TypeReference valueType)
     {
-        var beforeVariable = new VariableDefinition(property.PropertyType);
+        var beforeVariable = new VariableDefinition(valueType);
         setMethodBody.Variables.Add(beforeVariable);
-        var afterVariable = new VariableDefinition(property.PropertyType);
-        setMethodBody.Variables.Add(afterVariable);
-
-        index = InsertVariableAssignmentFromCurrentValue(index, property, afterVariable);
-
-        index = instructions.Insert(index,
-            Instruction.Create(OpCodes.Ldarg_0),
-            Instruction.Create(OpCodes.Ldstr, property.Name),
-            Instruction.Create(OpCodes.Ldloc, beforeVariable),
-            Instruction.Create(OpCodes.Ldloc, afterVariable));
-
-        index = instructions.Insert(index, CallEventInvoker(property).ToArray());
-
-        return AddBeforeVariableAssignment(index, property, beforeVariable);
-    }
-
-    int AddBeforeAfterInvokerCall(int index, PropertyDefinition property)
-    {
-        var beforeVariable = new VariableDefinition(typeSystem.ObjectReference);
-        setMethodBody.Variables.Add(beforeVariable);
-        var afterVariable = new VariableDefinition(typeSystem.ObjectReference);
+        var afterVariable = new VariableDefinition(valueType);
         setMethodBody.Variables.Add(afterVariable);
 
         index = InsertVariableAssignmentFromCurrentValue(index, property, afterVariable);

--- a/PropertyChanged.sln
+++ b/PropertyChanged.sln
@@ -67,6 +67,7 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyWithInvokerInterceptor", "TestAssemblies\AssemblyWithInvokerInterceptor\AssemblyWithInvokerInterceptor.csproj", "{4933F02F-72B1-48CC-B721-9C67BE72DD80}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyWithInvokerBeforeAfterInterceptor", "TestAssemblies\AssemblyWithInvokerBeforeAfterInterceptor\AssemblyWithInvokerBeforeAfterInterceptor.csproj", "{1102ED10-7E36-4C30-A116-7A053387CB3D}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyWithDisabledBeforeAfterForReadOnlyProperties", "TestAssemblies\AssemblyWithDisabledBeforeAfterForReadOnlyProperties\AssemblyWithDisabledBeforeAfterForReadOnlyProperties.csproj", "{E0BEDAB4-D441-4ECD-A18F-F3E2B3161421}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -350,6 +351,18 @@ Global
 		{1102ED10-7E36-4C30-A116-7A053387CB3D}.Release|ARM.Build.0 = Release|Any CPU
 		{1102ED10-7E36-4C30-A116-7A053387CB3D}.Release|x86.ActiveCfg = Release|Any CPU
 		{1102ED10-7E36-4C30-A116-7A053387CB3D}.Release|x86.Build.0 = Release|Any CPU
+		{E0BEDAB4-D441-4ECD-A18F-F3E2B3161421}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E0BEDAB4-D441-4ECD-A18F-F3E2B3161421}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E0BEDAB4-D441-4ECD-A18F-F3E2B3161421}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{E0BEDAB4-D441-4ECD-A18F-F3E2B3161421}.Debug|ARM.Build.0 = Debug|Any CPU
+		{E0BEDAB4-D441-4ECD-A18F-F3E2B3161421}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E0BEDAB4-D441-4ECD-A18F-F3E2B3161421}.Debug|x86.Build.0 = Debug|Any CPU
+		{E0BEDAB4-D441-4ECD-A18F-F3E2B3161421}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E0BEDAB4-D441-4ECD-A18F-F3E2B3161421}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E0BEDAB4-D441-4ECD-A18F-F3E2B3161421}.Release|ARM.ActiveCfg = Release|Any CPU
+		{E0BEDAB4-D441-4ECD-A18F-F3E2B3161421}.Release|ARM.Build.0 = Release|Any CPU
+		{E0BEDAB4-D441-4ECD-A18F-F3E2B3161421}.Release|x86.ActiveCfg = Release|Any CPU
+		{E0BEDAB4-D441-4ECD-A18F-F3E2B3161421}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -378,6 +391,7 @@ Global
 		{AE0D0B20-5F4C-48BA-A0DB-C00F2A70D146} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
 		{4933F02F-72B1-48CC-B721-9C67BE72DD80} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
 		{1102ED10-7E36-4C30-A116-7A053387CB3D} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
+		{E0BEDAB4-D441-4ECD-A18F-F3E2B3161421} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {ABD5CA78-3690-4D62-8642-3463D9FAE144}

--- a/PropertyChanged/ForceBeforeAfterAttribute.cs
+++ b/PropertyChanged/ForceBeforeAfterAttribute.cs
@@ -1,0 +1,8 @@
+namespace PropertyChanged;
+
+using System;
+
+/// <summary>Suppresses effect of `DisableBeforeAfterForReadOnlyProperties` config option for read-only properties. If the attribute is set then the property will always be notified with real before/after values instead of default values.</summary>
+public class ForceBeforeAfterAttribute : Attribute
+{
+}

--- a/TestAssemblies/AssemblyWithDisabledBeforeAfterForReadOnlyProperties/AssemblyWithDisabledBeforeAfterForReadOnlyProperties.csproj
+++ b/TestAssemblies/AssemblyWithDisabledBeforeAfterForReadOnlyProperties/AssemblyWithDisabledBeforeAfterForReadOnlyProperties.csproj
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+  <PropertyGroup>
+    <TargetFrameworks>net48;net6</TargetFrameworks>
+    <NoWarn>0067</NoWarn>
+    <DisableFody>true</DisableFody>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="../../PropertyChanged/PropertyChanged.csproj" />
+  </ItemGroup>
+</Project>

--- a/TestAssemblies/AssemblyWithDisabledBeforeAfterForReadOnlyProperties/ClassToTest.cs
+++ b/TestAssemblies/AssemblyWithDisabledBeforeAfterForReadOnlyProperties/ClassToTest.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using PropertyChanged;
+
+public class ClassToTest : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler PropertyChanged;
+    public List<(string PropertyName, bool HasDefaultValues)> Notified = new();
+
+    public string Trigger { get; set; } // trigger property with setter
+
+    [DependsOn(nameof(Trigger))] public int Int => throw new NotImplementedException();
+    [DependsOn(nameof(Trigger))] public Guid Guid => throw new NotImplementedException();
+    [DependsOn(nameof(Trigger))] public string String => throw new NotImplementedException();
+    [DependsOn(nameof(Trigger))] public object Object => throw new NotImplementedException();
+
+    [DependsOn(nameof(Trigger)), ForceBeforeAfter] public int RealInt => Trigger?.Length ?? 0;
+    [DependsOn(nameof(Trigger)), ForceBeforeAfter] public string RealString => Trigger;
+    protected virtual void OnPropertyChanged(string propertyName, object before, object after)
+    {
+        Notified.Add((propertyName, before == null && after == null));
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/TestAssemblies/AssemblyWithDisabledBeforeAfterForReadOnlyProperties/ClassToTestGeneric.cs
+++ b/TestAssemblies/AssemblyWithDisabledBeforeAfterForReadOnlyProperties/ClassToTestGeneric.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using PropertyChanged;
+
+public class ClassToTestGeneric : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler PropertyChanged;
+    public List<(string PropertyName, bool HasDefaultValues)> Notified = new();
+
+    public string Trigger { get; set; } // trigger property with setter
+
+    #region Primitive types
+    [DependsOn(nameof(Trigger))] public byte Byte => throw new NotImplementedException();
+    [DependsOn(nameof(Trigger))] public sbyte SByte => throw new NotImplementedException();
+    [DependsOn(nameof(Trigger))] public short Short => throw new NotImplementedException();
+    [DependsOn(nameof(Trigger))] public ushort UShort => throw new NotImplementedException();
+    [DependsOn(nameof(Trigger))] public int Int => throw new NotImplementedException();
+    [DependsOn(nameof(Trigger))] public uint UInt => throw new NotImplementedException();
+    [DependsOn(nameof(Trigger))] public long Long => throw new NotImplementedException();
+    [DependsOn(nameof(Trigger))] public ulong ULong => throw new NotImplementedException();
+    [DependsOn(nameof(Trigger))] public float Float => throw new NotImplementedException();
+    [DependsOn(nameof(Trigger))] public double Double => throw new NotImplementedException();
+    #endregion
+
+    #region Struct types
+    [DependsOn(nameof(Trigger))] public Guid Guid => throw new NotImplementedException();
+    #endregion
+
+    #region Class types
+    [DependsOn(nameof(Trigger))] public string String => throw new NotImplementedException();
+    [DependsOn(nameof(Trigger))] public object Object => throw new NotImplementedException();
+    #endregion
+
+    #region Forced properties
+    [DependsOn(nameof(Trigger)), ForceBeforeAfter] public int RealInt => Trigger?.Length ?? 0;
+    [DependsOn(nameof(Trigger)), ForceBeforeAfter] public string RealString => Trigger;
+    #endregion
+
+    protected virtual void OnPropertyChanged<T>(string propertyName, T before, T after)
+    {
+        Notified.Add((propertyName, EqualityComparer<T>.Default.Equals(before, default) && EqualityComparer<T>.Default.Equals(after, default)));
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/Tests/AssemblyWithDisabledBeforeAfterForReadOnlyPropertiesTests.cs
+++ b/Tests/AssemblyWithDisabledBeforeAfterForReadOnlyPropertiesTests.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Linq;
+using Fody;
+using Xunit;
+
+public class AssemblyWithDisabledBeforeAfterForReadOnlyPropertiesTests
+{
+    [Fact]
+    public void TestGenericOnPropertyChanged()
+    {
+        var weavingTask = new ModuleWeaver { DisableBeforeAfterForReadOnlyProperties = true };
+        var testResult = weavingTask.ExecuteTestRun(
+            "AssemblyWithDisabledBeforeAfterForReadOnlyProperties.dll",
+            ignoreCodes: new[] {"0x80131869"});
+        var instance = testResult.GetInstance("ClassToTestGeneric");
+        instance.Trigger = "Foo";
+        var notifies = instance.Notified;
+        Assert.Equal(new[]
+        {
+            ("Trigger", false), ("Byte", true), ("SByte", true), ("Short", true), ("UShort", true), ("Int", true), ("UInt", true), ("Long", true), ("ULong", true), ("Float", true), ("Double", true), ("Guid", true), ("String", true), ("Object", true), ("RealInt", false), ("RealString", false)
+        }.OrderBy(x => x.Item1), ((IEnumerable<(string, bool)>)notifies).OrderBy( x => x.Item1));
+    }
+
+    [Fact]
+    public void TestNonGenericOnPropertyChanged()
+    {
+        var weavingTask = new ModuleWeaver { DisableBeforeAfterForReadOnlyProperties = true };
+        var testResult = weavingTask.ExecuteTestRun(
+            "AssemblyWithDisabledBeforeAfterForReadOnlyProperties.dll",
+            ignoreCodes: new[] {"0x80131869"});
+        var instance = testResult.GetInstance("ClassToTest");
+        instance.Trigger = "Foo";
+        var notifies = instance.Notified;
+        Assert.Equal(new[]
+        {
+            ("Trigger", false), ("Int", true), ("Guid", true), ("String", true), ("Object", true), ("RealInt", false), ("RealString", false)
+        }.OrderBy(x => x.Item1), ((IEnumerable<(string, bool)>)notifies).OrderBy( x => x.Item1));
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -36,5 +36,6 @@
     <ProjectReference Include="..\TestAssemblies\AssemblyWithTypeFilter\AssemblyWithTypeFilter.csproj" />
     <ProjectReference Include="..\TestAssemblies\AssemblyWithInheritance\AssemblyWithInheritance.csproj" />
     <ProjectReference Include="..\TestAssemblies\AssemblyWithPropertyAttributes\AssemblyWithPropertyAttributes.csproj" />
+    <ProjectReference Include="..\TestAssemblies\AssemblyWithDisabledBeforeAfterForReadOnlyProperties\AssemblyWithDisabledBeforeAfterForReadOnlyProperties.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
When the option enabled in XML config:
```xml
<PropertyChanged DisabledBeforeAfterForReadOnlyPropertie="true" />
```
then instead of actual before/after values for read-only properties it will provide default values.
If you still need to receive real values then you can add [ForceBeforeAfter] for such property.

In most cases you only need to track values for settable properties and only aware when read only property changes so you can update description or tooltip. Often before value and even after value for such property may not be calculatable because of incomplete object state and potential NRE. So with that option you can avoid such errors and significantly improve performance in some cases if you need to track before/after values (i.e. with Interceptor).

Example:
```csharp
public class MyClass : INotifyPropertyChanged
{
    public string MyProperty { get; set; }
    [DependsOn("MyProperty")] public int MyPropertyLength => MyProperty.Length;

    public event PropertyChangedEventHandler PropertyChanged;

    public void OnPropertyChanged(string propertyName, object before, object after)
    {
        PropertyChanged?.Invoke(new PropertyChangedEventArgs(propertyName));
    } 
}
```

Without the option:
```csharp
public class MyClass : INotifyPropertyChanged
{
    string myProperty;
    public string MyProperty 
    { 
        get => myProperty;
        set => {
            var beforeMyProperty = MyProperty;
            var beforeMyPropertyLength = MyPropertyLength; // NRE for first assignment because current value of MyProperty is null
            myProperty = value;
            var afterMyProperty =  MyProperty;
            var afterMyPropertyLength = MyPropertyLength;
            OnPropertyChanged("MyPropertyLength", beforeMyPropertyLength, afterMyPropertyLength);
            OnPropertyChanged("MyProperty", beforeMyProperty, afterMyProperty);
        }
    }

    [DependsOn("MyProperty")] public int MyPropertyLength => MyProperty.Length;

    public event PropertyChangedEventHandler PropertyChanged;

    public void OnPropertyChanged(string propertyName, object before, object after)
    {
        PropertyChanged?.Invoke(new PropertyChangedEventArgs(propertyName));
    } 
}
```

With the option:
```csharp
public class MyClass : INotifyPropertyChanged
{
    string myProperty;
    public string MyProperty 
    { 
        get => myProperty;
        set => {
            var beforeMyProperty = MyProperty;
            myProperty = value;
            var afterMyProperty =  MyProperty;
            OnPropertyChanged("MyPropertyLength", null, null);
            OnPropertyChanged("MyProperty", beforeMyProperty, afterMyProperty);
        }
    }

    [DependsOn("MyProperty")] public int MyPropertyLength => MyProperty.Length;

    public event PropertyChangedEventHandler PropertyChanged;

    public void OnPropertyChanged(string propertyName, object before, object after)
    {
        PropertyChanged?.Invoke(new PropertyChangedEventArgs(propertyName));
    } 
}
```

If use [ForceBeforeAfter] like:
```csharp
[ForceBeforeAfter, DependsOn("MyProperty")] public int MyPropertyLength => MyProperty.Length;
```
then output will be same with and without the option.