### PR TITLE
Allow to use custom interface as INotifyPropertyChangedInvoker

### DIFF
--- a/PropertyChanged.Fody/CecilUtils.cs
+++ b/PropertyChanged.Fody/CecilUtils.cs
@@ -1,17 +1,34 @@
+#nullable enable
+
+using Fody;
 using Mono.Cecil;
 
 public static class CecilUtils
 {
+    /// <summary>Splits assembly qualified name like "System.Int32, System.Runtime" to type name ("System.Int32") and assembly name ("System.Runtime").</summary>
+    public static (string, string) SplitTypeAndAssemblyName(string assemblyQualifiedName)
+    {
+        var assemblySplitIndex = assemblyQualifiedName.IndexOf(',');
+        return (assemblyQualifiedName.Substring(0, assemblySplitIndex), assemblyQualifiedName.Substring(assemblySplitIndex + 1).TrimStart());
+    }
+
     /// <summary>Makes <see cref="TypeReference"/> from <paramref name="assemblyQualifiedName"/> like "System.Int32, System.Runtime".</summary>
     public static TypeReference MakeTypeReference(string assemblyQualifiedName)
     {
-        var assemblySplitIndex = assemblyQualifiedName.IndexOf(',');
-        var assemblyReference = AssemblyNameReference.Parse(assemblyQualifiedName.Substring(assemblySplitIndex + 1).TrimStart());
-        return MakeTypeReference(assemblyQualifiedName.Substring(0, assemblySplitIndex), assemblyReference);
+        var (typeName, assemblyName) = SplitTypeAndAssemblyName(assemblyQualifiedName);
+        return MakeTypeReference(typeName, AssemblyNameReference.Parse(assemblyName));
+    }
+
+    /// <summary>Makes <see cref="TypeReference"/> from <paramref name="assemblyQualifiedName"/> like "System.Int32, System.Runtime". Assembly reference will be resolved from <paramref name="module"/>.</summary>
+    public static TypeReference MakeTypeReference(string assemblyQualifiedName, ModuleDefinition module)
+    {
+        var (typeName, assemblyName) = SplitTypeAndAssemblyName(assemblyQualifiedName);
+        var assemblyReference = module.Assembly.Name.Name == assemblyName ? (IMetadataScope)module : module.GetAssemblyReference(assemblyName) ?? throw new WeavingException($"Can't resolve reference to assembly {assemblyName} for {assemblyQualifiedName}");
+        return MakeTypeReference(typeName, assemblyReference);
     }
 
     /// <summary>Makes <see cref="TypeReference"/> from <paramref name="fullTypeName"/> like "System.Int32" declared in <paramref name="assemblyReference"/>.</summary>
-    public static TypeReference MakeTypeReference(string fullTypeName, AssemblyNameReference assemblyReference)
+    public static TypeReference MakeTypeReference(string fullTypeName, IMetadataScope assemblyReference)
     {
         var namespaceSplitIndex = fullTypeName.LastIndexOf('.');
         return new TypeReference(fullTypeName.Substring(0, namespaceSplitIndex), fullTypeName.Substring(namespaceSplitIndex + 1), null, assemblyReference);

--- a/PropertyChanged.Fody/Config/AddPropertyChangedInvokerConfig.cs
+++ b/PropertyChanged.Fody/Config/AddPropertyChangedInvokerConfig.cs
@@ -1,11 +1,59 @@
+#nullable enable
+
+using System;
+using System.Xml;
+using Mono.Cecil;
+
+public enum PropertyChangedInvokerType
+{
+    None,
+    Default,
+    Custom
+}
+
 public partial class ModuleWeaver
 {
-    bool? addPropertyChangedInvoker;
+    const string PropertyChangedAssemblyName = "PropertyChanged";
+
+    bool propertyChangedInvokerResolved;
+    TypeReference? propertyChangedInvoker;
+
+    /// <summary>
+    /// Returns type of <see cref="PropertyChangedInvoker"/>:
+    /// - None    - when not set;
+    /// - Default - when PropertyChanged version used;
+    /// - Custom  - when custom interface from weaved assembly used.
+    /// </summary>
+    PropertyChangedInvokerType PropertyChangedInvokerType => PropertyChangedInvoker is { } invoker
+        ? (invoker.Scope.Name == PropertyChangedAssemblyName ? PropertyChangedInvokerType.Default : PropertyChangedInvokerType.Custom)
+        : PropertyChangedInvokerType.None;
 
     /// <summary>Should it inject INotifyPropertyChangedInvoker interface with <see cref="ProcessPropertyChangedInvoker"/>. If set to <c>true</c> then reference wouldn't be clean and you shouldn't use PrivateAssets='all' in package reference.</summary>
-    public bool AddPropertyChangedInvoker
+    public TypeReference? PropertyChangedInvoker
     {
-        get => addPropertyChangedInvoker ??= GetConfigBoolean("AddPropertyChangedInvoker") ?? false;
-        set => addPropertyChangedInvoker = value;
+        get
+        {
+            if (propertyChangedInvokerResolved) return propertyChangedInvoker;
+            if (GetConfigValue("AddPropertyChangedInvoker") is { } value)                           // check if value presents in the config
+            {
+                try
+                {
+                    if (XmlConvert.ToBoolean(value))                                                // if value is boolean and is true then should use standard interface
+                        propertyChangedInvoker = new TypeReference("PropertyChanged", "INotifyPropertyChangedInvoker", null, ModuleDefinition.GetAssemblyReference(PropertyChangedAssemblyName));
+                }
+                catch (FormatException)
+                {
+                    propertyChangedInvoker = CecilUtils.MakeTypeReference(value, ModuleDefinition); // if failed to parse as boolean then assume it is an assembly qualified type name
+                }
+            }
+            propertyChangedInvokerResolved = true;
+            return propertyChangedInvoker;
+        }
+        set
+        {
+            propertyChangedInvoker = value;
+            propertyChangedInvokerResolved = true;
+        }
     }
+
 }

--- a/PropertyChanged.Fody/Config/ConfigHelpers.cs
+++ b/PropertyChanged.Fody/Config/ConfigHelpers.cs
@@ -1,10 +1,14 @@
+#nullable enable
+
 using System.Linq;
 using System.Xml;
 
 public partial class ModuleWeaver
 {
+    string? GetConfigValue(string optionName) => Config?.Attributes(optionName).Select(a => a.Value).SingleOrDefault();
+
     /// <summary>Returns boolean value of config option if set. Otherwise returns <c>null</c>.</summary>
-    bool? GetConfigBoolean(string optionName) => Config?.Attributes(optionName).Select(a => a.Value).SingleOrDefault() is { } value ? XmlConvert.ToBoolean(value.ToLowerInvariant()) : null;
+    bool? GetConfigBoolean(string optionName) => GetConfigValue(optionName) is { } value ? XmlConvert.ToBoolean(value.ToLowerInvariant()) : null;
     /// <summary>Sets <paramref name="option"/> from config if <paramref name="optionName"/> set in the config. Keep untouched otherwise.</summary>
     void SetFromConfigIfAvailable(ref bool option, string optionName)
     {

--- a/PropertyChanged.Fody/InterceptorFinder.cs
+++ b/PropertyChanged.Fody/InterceptorFinder.cs
@@ -57,21 +57,18 @@ Intercept(object target, Action firePropertyChanged, string propertyName, object
             return true;
         }
 
-        if (AddPropertyChangedInvoker)
+        if (IsInvokerSingleStringInterceptionMethod(methodDefinition)) // Intercept(INotifyPropertyChangedInvoker, string) ?
         {
-            if (IsInvokerSingleStringInterceptionMethod(methodDefinition)) // Intercept(INotifyPropertyChangedInvoker, string) ?
-            {
-                usesInvoker = true;
-                interceptorType = InvokerTypes.String;
-                return true;
-            }
+            usesInvoker = true;
+            interceptorType = InvokerTypes.String;
+            return true;
+        }
 
-            if (IsInvokerBeforeAfterInterceptionMethod(methodDefinition))  // Intercept(INotifyPropertyChangedInvoker, object, object) ?
-            {
-                usesInvoker = true;
-                interceptorType = InvokerTypes.BeforeAfter;
-                return true;
-            }
+        if (IsInvokerBeforeAfterInterceptionMethod(methodDefinition))  // Intercept(INotifyPropertyChangedInvoker, object, object) ?
+        {
+            usesInvoker = true;
+            interceptorType = InvokerTypes.BeforeAfter;
+            return true;
         }
 
         interceptorType = default;
@@ -105,7 +102,7 @@ Intercept(object target, Action firePropertyChanged, string propertyName, object
     {
         var parameters = method.Parameters;
         return parameters.Count == 2
-               && parameters[0].ParameterType.FullName == "PropertyChanged.INotifyPropertyChangedInvoker"
+               && parameters[0].ParameterType.FullName == PropertyChangedInvoker?.FullName
                && parameters[1].ParameterType.FullName == "System.String";
     }
 
@@ -114,7 +111,7 @@ Intercept(object target, Action firePropertyChanged, string propertyName, object
     {
         var parameters = method.Parameters;
         return parameters.Count == 4
-               && parameters[0].ParameterType.FullName == "PropertyChanged.INotifyPropertyChangedInvoker"
+               && parameters[0].ParameterType.FullName == PropertyChangedInvoker?.FullName
                && parameters[1].ParameterType.FullName == "System.String"
                && parameters[2].ParameterType.FullName == "System.Object"
                && parameters[3].ParameterType.FullName == "System.Object";

--- a/PropertyChanged.Fody/MethodInjector.cs
+++ b/PropertyChanged.Fody/MethodInjector.cs
@@ -103,7 +103,7 @@ public partial class ModuleWeaver
         }
 
         invokerType = InvokerTypes.PropertyChangedArg;
-        return AddPropertyChangedInvoker ? FindInvokePropertyChangedRecursively(targetType) : InjectEventArgsMethod(targetType, propertyChangedField); // if AddPropertyChangedInvoker set then reuse implementation of INotifyPropertyChangedInvoker.InvokePropertyChanged
+        return PropertyChangedInvoker != null ? FindInvokePropertyChangedRecursively(targetType) : InjectEventArgsMethod(targetType, propertyChangedField); // if AddPropertyChangedInvoker set then reuse implementation of INotifyPropertyChangedInvoker.InvokePropertyChanged
     }
 
     /// <summary>Find recursively <c>InvokePropertyChanged</c> in <paramref name="targetType"/> or in it's base types.</summary>
@@ -114,14 +114,14 @@ public partial class ModuleWeaver
         {
             foreach (var method in type.Methods)
             {
-                if (method.Name == "InvokePropertyChanged" && method.Parameters.Count == 1 && method.Parameters[0].ParameterType.FullName == PropertyChangedEventArgsReference.FullName)
+                if (method.Name == invokePropertyChangedMethodName && method.Parameters.Count == 1 && method.Parameters[0].ParameterType.FullName == PropertyChangedEventArgsReference.FullName)
                     return method;
             }
 
             type = type.BaseType?.Resolve();
         } while (type != null);
 
-        throw new WeavingException($"Can't find InvokePropertyChanged for {targetType.FullName}");
+        throw new WeavingException($"Can't find {invokePropertyChangedMethodName} for {targetType.FullName}");
     }
 
     MethodDefinition InjectFsharp(TypeDefinition targetType, FieldDefinition fsharpEvent)

--- a/PropertyChanged.Fody/ModuleWeaver.cs
+++ b/PropertyChanged.Fody/ModuleWeaver.cs
@@ -40,5 +40,5 @@ public partial class ModuleWeaver: BaseModuleWeaver
             CleanAttributes();
     }
 
-    public override bool ShouldCleanReference => ShouldCleanAttributes && !AddPropertyChangedInvoker;
+    public override bool ShouldCleanReference => ShouldCleanAttributes && PropertyChangedInvokerType != PropertyChangedInvokerType.Default;
 }

--- a/PropertyChanged.sln
+++ b/PropertyChanged.sln
@@ -67,7 +67,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyWithInvokerInterceptor", "TestAssemblies\AssemblyWithInvokerInterceptor\AssemblyWithInvokerInterceptor.csproj", "{4933F02F-72B1-48CC-B721-9C67BE72DD80}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyWithInvokerBeforeAfterInterceptor", "TestAssemblies\AssemblyWithInvokerBeforeAfterInterceptor\AssemblyWithInvokerBeforeAfterInterceptor.csproj", "{1102ED10-7E36-4C30-A116-7A053387CB3D}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyWithDisabledBeforeAfterForReadOnlyProperties", "TestAssemblies\AssemblyWithDisabledBeforeAfterForReadOnlyProperties\AssemblyWithDisabledBeforeAfterForReadOnlyProperties.csproj", "{E0BEDAB4-D441-4ECD-A18F-F3E2B3161421}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyWithCustomInvokerInterceptor", "TestAssemblies\AssemblyWithCustomInvokerInterceptor\AssemblyWithCustomInvokerInterceptor.csproj", "{5476E61C-712C-46B3-8E19-4983C727F07D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -363,6 +366,18 @@ Global
 		{E0BEDAB4-D441-4ECD-A18F-F3E2B3161421}.Release|ARM.Build.0 = Release|Any CPU
 		{E0BEDAB4-D441-4ECD-A18F-F3E2B3161421}.Release|x86.ActiveCfg = Release|Any CPU
 		{E0BEDAB4-D441-4ECD-A18F-F3E2B3161421}.Release|x86.Build.0 = Release|Any CPU
+		{5476E61C-712C-46B3-8E19-4983C727F07D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5476E61C-712C-46B3-8E19-4983C727F07D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5476E61C-712C-46B3-8E19-4983C727F07D}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{5476E61C-712C-46B3-8E19-4983C727F07D}.Debug|ARM.Build.0 = Debug|Any CPU
+		{5476E61C-712C-46B3-8E19-4983C727F07D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5476E61C-712C-46B3-8E19-4983C727F07D}.Debug|x86.Build.0 = Debug|Any CPU
+		{5476E61C-712C-46B3-8E19-4983C727F07D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5476E61C-712C-46B3-8E19-4983C727F07D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5476E61C-712C-46B3-8E19-4983C727F07D}.Release|ARM.ActiveCfg = Release|Any CPU
+		{5476E61C-712C-46B3-8E19-4983C727F07D}.Release|ARM.Build.0 = Release|Any CPU
+		{5476E61C-712C-46B3-8E19-4983C727F07D}.Release|x86.ActiveCfg = Release|Any CPU
+		{5476E61C-712C-46B3-8E19-4983C727F07D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -392,6 +407,7 @@ Global
 		{4933F02F-72B1-48CC-B721-9C67BE72DD80} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
 		{1102ED10-7E36-4C30-A116-7A053387CB3D} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
 		{E0BEDAB4-D441-4ECD-A18F-F3E2B3161421} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
+		{5476E61C-712C-46B3-8E19-4983C727F07D} = {546A6338-E25E-4796-AF08-A4742E3BDF7B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {ABD5CA78-3690-4D62-8642-3463D9FAE144}

--- a/TestAssemblies/AssemblyWithCustomInvokerInterceptor/AssemblyWithCustomInvokerInterceptor.csproj
+++ b/TestAssemblies/AssemblyWithCustomInvokerInterceptor/AssemblyWithCustomInvokerInterceptor.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net48;net6</TargetFrameworks>
+    <NoWarn>0067</NoWarn>
+    <DisableFody>true</DisableFody>
+  </PropertyGroup>
+
+</Project>

--- a/TestAssemblies/AssemblyWithCustomInvokerInterceptor/ClassToTest.cs
+++ b/TestAssemblies/AssemblyWithCustomInvokerInterceptor/ClassToTest.cs
@@ -1,0 +1,9 @@
+﻿using System.ComponentModel;
+
+public class ClassToTest :
+    INotifyPropertyChanged
+{
+    public string Property1 { get; set; }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+}

--- a/TestAssemblies/AssemblyWithCustomInvokerInterceptor/ICustomNotifyPropertyChangedInvoker.cs
+++ b/TestAssemblies/AssemblyWithCustomInvokerInterceptor/ICustomNotifyPropertyChangedInvoker.cs
@@ -1,0 +1,8 @@
+namespace AssemblyWithCustomInvokerInterceptor;
+
+using System.ComponentModel;
+
+public interface ICustomNotifyPropertyChangedInvoker
+{
+    void InvokePropertyChanged(PropertyChangedEventArgs args);
+}

--- a/TestAssemblies/AssemblyWithCustomInvokerInterceptor/PropertyNotificationInterceptor.cs
+++ b/TestAssemblies/AssemblyWithCustomInvokerInterceptor/PropertyNotificationInterceptor.cs
@@ -1,0 +1,13 @@
+﻿using System.ComponentModel;
+using AssemblyWithCustomInvokerInterceptor;
+
+public static class PropertyChangedNotificationInterceptor
+{
+    public static void Intercept(ICustomNotifyPropertyChangedInvoker invoker, string propertyName)
+    {
+        invoker.InvokePropertyChanged(new PropertyChangedEventArgs(propertyName));
+        InterceptCalled = true;
+    }
+
+    public static bool InterceptCalled { get; set; }
+}

--- a/Tests/AssemblyWithInvokerInterceptorTests.cs
+++ b/Tests/AssemblyWithInvokerInterceptorTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Xml.Linq;
 using Fody;
 using Xunit;
 
@@ -7,7 +8,8 @@ public class AssemblyWithInvokerInterceptorTests
     [Fact]
     public void Simple()
     {
-        var weavingTask = new ModuleWeaver { AddPropertyChangedInvoker = true };
+        var xElement = XElement.Parse("<PropertyChanged AddPropertyChangedInvoker='true'/>");
+        var weavingTask = new ModuleWeaver { Config = xElement };
         var testResult = weavingTask.ExecuteTestRun(
             "AssemblyWithInvokerInterceptor.dll",
             ignoreCodes: new[] {"0x80131869"});
@@ -22,9 +24,28 @@ public class AssemblyWithInvokerInterceptorTests
     }
 
     [Fact]
+    public void CustomInvokerType()
+    {
+        var xElement = XElement.Parse("<PropertyChanged AddPropertyChangedInvoker='AssemblyWithCustomInvokerInterceptor.ICustomNotifyPropertyChangedInvoker, AssemblyWithCustomInvokerInterceptor'/>");
+        var weavingTask = new ModuleWeaver { Config = xElement };
+        var testResult = weavingTask.ExecuteTestRun(
+            "AssemblyWithCustomInvokerInterceptor.dll",
+            ignoreCodes: new[] {"0x80131869"});
+
+        var assembly = testResult.Assembly;
+        var instance = assembly.GetInstance("ClassToTest");
+        EventTester.TestProperty(instance, false);
+        var type = assembly.GetType("PropertyChangedNotificationInterceptor");
+        var propertyInfo = type.GetProperty("InterceptCalled", BindingFlags.Static | BindingFlags.Public)!;
+        var value = (bool)propertyInfo.GetValue(null, null);
+        Assert.True(value);
+    }
+
+    [Fact]
     public void BeforeAfter()
     {
-        var weavingTask = new ModuleWeaver { AddPropertyChangedInvoker = true };
+        var xElement = XElement.Parse("<PropertyChanged AddPropertyChangedInvoker='true'/>");
+        var weavingTask = new ModuleWeaver { Config = xElement };
         var testResult = weavingTask.ExecuteTestRun(
             "AssemblyWithInvokerBeforeAfterInterceptor.dll",
             ignoreCodes: new[] {"0x80131869"});

--- a/Tests/PropertyChangedInvokerProcessingTests.cs
+++ b/Tests/PropertyChangedInvokerProcessingTests.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Xml.Linq;
 using Fody;
 using PropertyChanged;
 using Xunit;
@@ -9,7 +10,8 @@ public class PropertyChangedInvokerProcessingTests
     [Fact]
     public void ShouldImplementINotifyPropertyChangedInvokerInterfaceWhenConfigEnabled()
     {
-        var weaver = new ModuleWeaver { AddPropertyChangedInvoker = true };
+        var xElement = XElement.Parse("<PropertyChanged AddPropertyChangedInvoker='true'/>");
+        var weaver = new ModuleWeaver { Config = xElement };
         var testResult = weaver.ExecuteTestRun("AssemblyToProcess.dll");
         var instance = testResult.GetInstance("ClassParentWithProperty");
         Assert.True(instance is INotifyPropertyChangedInvoker);

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -37,5 +37,6 @@
     <ProjectReference Include="..\TestAssemblies\AssemblyWithInheritance\AssemblyWithInheritance.csproj" />
     <ProjectReference Include="..\TestAssemblies\AssemblyWithPropertyAttributes\AssemblyWithPropertyAttributes.csproj" />
     <ProjectReference Include="..\TestAssemblies\AssemblyWithDisabledBeforeAfterForReadOnlyProperties\AssemblyWithDisabledBeforeAfterForReadOnlyProperties.csproj" />
+    <ProjectReference Include="..\TestAssemblies\AssemblyWithCustomInvokerInterceptor\AssemblyWithCustomInvokerInterceptor.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
AddPropertyChangedInvoker XML config option extended and now allow to use it as boolean (old way):
```xml
<PropertyChanged AddPropertyChangedInvoker="true" />
```
or as interface type name:
```xml
<PropertyChanged AddPropertyChangedInvoker="AssemblyWithCustomInvokerInterceptor.ICustomNotifyPropertyChangedInvoker, AssemblyWithCustomInvokerInterceptor" />
```
In latter case you don't need to preserve reference to `PropertyChanged` assembly and instead use custom interface with same API:
```csharp
public interface ICustomNotifyPropertyChangedInvoker
{
    void InvokePropertyChanged(PropertyChangedEventArgs args);
}
```
It also allows you to use same interface in another assembly without referencing `PropertyChanged` building more universal APIs.