### PR TITLE
Refactored code to not throw exception for valid config

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Version>3.4.1-slg.5</Version>
+    <Version>3.4.1-slg.6</Version>
     <LangVersion>latest</LangVersion>
     <NoWarn>NU5118</NoWarn>
   </PropertyGroup>

--- a/PropertyChanged.Fody/Config/AddPropertyChangedInvokerConfig.cs
+++ b/PropertyChanged.Fody/Config/AddPropertyChangedInvokerConfig.cs
@@ -1,7 +1,5 @@
 #nullable enable
 
-using System;
-using System.Xml;
 using Mono.Cecil;
 
 public enum PropertyChangedInvokerType
@@ -36,15 +34,10 @@ public partial class ModuleWeaver
             if (propertyChangedInvokerResolved) return propertyChangedInvoker;
             if (GetConfigValue("AddPropertyChangedInvoker") is { } value)                           // check if value presents in the config
             {
-                try
-                {
-                    if (XmlConvert.ToBoolean(value))                                                // if value is boolean and is true then should use standard interface
-                        propertyChangedInvoker = new TypeReference("PropertyChanged", "INotifyPropertyChangedInvoker", null, ModuleDefinition.GetAssemblyReference(PropertyChangedAssemblyName));
-                }
-                catch (FormatException)
-                {
+                if (!TryParseBoolean(value, out var addPropertyChangedInvoker))                     
                     propertyChangedInvoker = CecilUtils.MakeTypeReference(value, ModuleDefinition); // if failed to parse as boolean then assume it is an assembly qualified type name
-                }
+                else if (addPropertyChangedInvoker)                                                 // else if value is boolean and is true then use standard interface
+                    propertyChangedInvoker = new TypeReference("PropertyChanged", "INotifyPropertyChangedInvoker", null, ModuleDefinition.GetAssemblyReference(PropertyChangedAssemblyName));
             }
             propertyChangedInvokerResolved = true;
             return propertyChangedInvoker;

--- a/PropertyChanged.Fody/Config/ConfigHelpers.cs
+++ b/PropertyChanged.Fody/Config/ConfigHelpers.cs
@@ -15,4 +15,11 @@ public partial class ModuleWeaver
         if (GetConfigBoolean(optionName) is {} value)
             option = value;
     }
+
+    /// <summary>Tries to parse <paramref name="xmlValue"/> as boolean. Can't use <see cref="XmlConvert.ToBoolean"/> because it throws exception if value can't be parsed.</summary>
+    bool TryParseBoolean(string xmlValue, out bool value)
+    {
+        (var result, value) = xmlValue.ToLowerInvariant() switch { "1" or "true" => (true, true), "0" or "false" => (true, false), _ => (false, false) };
+        return result;
+    }
 }

--- a/PropertyChanged.sln.DotSettings
+++ b/PropertyChanged.sln.DotSettings
@@ -590,6 +590,7 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=NAMESPACE_005FALIAS/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FRESOURCE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EdotCover_002EIde_002ECore_002EFilterManagement_002EModel_002ESolutionFilterSettingsManagerMigrateSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpFileLayoutPatternsUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
Fixed PropertyChangedInvoker to not throw exception if value for AddPropertyChangedInvoker can't be parsed as boolean (it is a valid case).