### PR TITLE
Support read only auto properties notification

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Version>3.4.2-slg.2</Version>
+    <Version>3.4.2-slg.3</Version>
     <LangVersion>latest</LangVersion>
     <NoWarn>NU5118</NoWarn>
   </PropertyGroup>

--- a/PropertyChanged.Fody/ConstructorWeaver.cs
+++ b/PropertyChanged.Fody/ConstructorWeaver.cs
@@ -1,5 +1,6 @@
 ﻿namespace PropertyChanged.Fody;
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Mono.Cecil;
@@ -13,9 +14,14 @@ using Mono.Collections.Generic;
 /// </summary>
 public readonly struct ConstructorWeaver
 {
-    readonly TypeNode typeNode;
+    readonly ModuleWeaver weaver;
+    readonly TypeNode     typeNode;
 
-    public ConstructorWeaver(TypeNode typeNode) { this.typeNode = typeNode; }
+    public ConstructorWeaver(ModuleWeaver weaver, TypeNode typeNode)
+    {
+        this.weaver   = weaver;
+        this.typeNode = typeNode;
+    }
 
     /// <summary>Executes weaver for pre-configured <see cref="typeNode"/>.</summary>
     public void Execute()
@@ -48,35 +54,53 @@ public readonly struct ConstructorWeaver
     /// </summary>
     void WeaveConstructor(MethodDefinition constructor)
     {
-        var               instructions              = constructor.Body.Instructions;
-        var               fieldAssignmentStartIndex = 0;
-        List<Instruction> movedInstructions         = null; // will contains instructions moved after constructor, for implicit initialization fields initialized before base constructor call, but for property setter calls these should be after base constructor call
-        var               currentIndex              = 0;
+        var constructorBody      = constructor.Body;
+        var instructions         = constructorBody.Instructions;
+        var constructorCallIndex = FindConstructorCallIndex(instructions);
+        if (constructorCallIndex < 0)
+            return;
+
+        var constructorCall = instructions[constructorCallIndex];
+        var insertIndex     = constructorCallIndex + 1; // set insert index right after constructor, because all setters should be invoked after base constructor call
+        
+        var fieldAssignmentStartIndex = 0;
+        var currentIndex              = 0;
+
         // iterate over all instructions
-        while (currentIndex < instructions.Count)
+        while (true)
         {
             var instruction = instructions[currentIndex];
-            // checks if instruction is constructor call, in that case process and break because all inline fields initialized before constructor call
-            if (IsConstructorCall(instruction))
-            {
-                ProcessConstructorCall(instructions, currentIndex, movedInstructions);
-                return;
-            }
-            
+            if (instruction == constructorCall)
+                break;
+
             // if it is a field assignment then process it and move to movedInstructions if is one of notified properties fields
-            if (instruction.OpCode == OpCodes.Stfld)
+            if (instruction.OpCode == OpCodes.Stfld && TryGetNotifyProperty((FieldReference)instruction.Operand, out var property))
             {
-                currentIndex              = ProcessFieldAssignment(instructions, fieldAssignmentStartIndex, currentIndex, ref movedInstructions); // will be set to next instruction index to process
-                fieldAssignmentStartIndex = currentIndex;
+                insertIndex  = ProcessFieldAssignment(constructorBody, instructions, insertIndex, fieldAssignmentStartIndex, currentIndex, property); // moves property notification to insert index and returns new insert index
+                currentIndex = fieldAssignmentStartIndex;                                                                                             // ProcessFieldAssignment moves all field assignment block after constructor so need to reset current index
             }
-            else // otherwise just go to next instruction
+            else                                                                                                                                      // otherwise just go to next instruction
                 ++currentIndex;
         }
     }
 
-    /// <summary>Checks if <paramref name="instruction"/> is a constructor call.</summary>
-    bool IsConstructorCall(Instruction instruction) => instruction.OpCode == OpCodes.Call && instruction.Operand is MethodReference { Name: ".ctor" };
+    /// <summary>Returns index of constructor call.</summary>
+    int FindConstructorCallIndex(Collection<Instruction> instructions)
+    {
+        var index = 0;
+        foreach (var instruction in instructions)
+        {
+            if (IsConstructorCall(instruction))
+                return index;
+            ++index;
+        }
 
+        return -1;
+    }
+
+    /// <summary>Checks if <paramref name="instruction"/> is a constructor call.</summary>
+    static bool IsConstructorCall(Instruction instruction) => instruction.OpCode == OpCodes.Call && instruction.Operand is MethodReference { Name: ".ctor" };
+    
     /// <summary>Process constructor call. Basically inserts all <paramref name="movedInstructions"/> after constructor call.</summary>
     void ProcessConstructorCall(Collection<Instruction> instructions, int currentIndex, List<Instruction> movedInstructions)
     {
@@ -85,32 +109,124 @@ public readonly struct ConstructorWeaver
         foreach (var instruction in movedInstructions)
             instructions.Insert(insertIndex++, instruction);
     }
-
-    /// <summary>Process field assignment. If it is a backing field for one of notified properties then it replaces field assignment with setter call and moves whole assignment to <paramref name="movedInstructions"/>.</summary>
-    int ProcessFieldAssignment(Collection<Instruction> instructions, int fieldAssignmentStartIndex, int currentIndex, ref List<Instruction> movedInstructions)
+    
+    /// <summary>Process field assignment. If it is a backing field for one of notified properties then it replaces field assignment with setter call and moves whole assignment tp <paramref name="insertIndex"/>, because implicit fields assigned before constructor, but all properties setters should be invoked after base constructor.</summary>
+    int ProcessFieldAssignment(MethodBody constructorBody, Collection<Instruction> instructions, int insertIndex, int fieldAssignmentStartIndex, int storeFieldIndex, PropertyDefinition property)
     {
-        var field = (FieldReference)instructions[currentIndex].Operand;
-        if (!field.IsBackingField()) return currentIndex + 1; // only care about backing fields
-        
-        var propertyData = typeNode.PropertyDatas.FirstOrDefault(pd => pd.Value.BackingFieldReference == field).Value;
-        if (propertyData == null) return currentIndex + 1;    // ignore non-notified properties backing fields
-        
-        movedInstructions ??= new();
-        MoveInstructions(instructions, fieldAssignmentStartIndex, currentIndex, movedInstructions);            // move whole field assignment to movedInstructions before store field
-        var setter = propertyData.PropertyDefinition.SetMethod;
-        movedInstructions.Add(Instruction.Create(setter.IsVirtual ? OpCodes.Callvirt : OpCodes.Call, setter)); // and then replace store field operation with setter call 
-        instructions.RemoveAt(fieldAssignmentStartIndex);
-        return fieldAssignmentStartIndex;
+        MoveFieldAssignment(instructions, insertIndex, fieldAssignmentStartIndex, storeFieldIndex); // move whole field assignment to insert index, insert index won't change because it should be after field and number of removed instructions same as number of inserted insteructions
+
+        storeFieldIndex = insertIndex - 1; // one step back to point store field instruction
+        return property.SetMethod is { } setter ? InsertSetterCall(instructions, storeFieldIndex, setter) : InsertEventInvocation(constructorBody, instructions, storeFieldIndex, property);
     }
 
-    /// <summary>Moves instruction range from one collection to another.</summary>
-    void MoveInstructions(Collection<Instruction> instructions, int start, int end, List<Instruction> targetInstructions)
+    /// <summary>Inserts setter call instead of field assignment.</summary>
+    int InsertSetterCall(Collection<Instruction> instructions, int index, MethodDefinition setter)
     {
-        for (var index = start; index < end; ++index)
+        instructions.RemoveAt(index);
+        instructions.Insert(index, Instruction.Create(setter.IsVirtual ? OpCodes.Callvirt : OpCodes.Call, setter));
+        return index + 1;
+    }
+
+    /// <summary>Inserts event invocation for <paramref name="propertyDefinition"/> if it was changed.</summary>
+    int InsertEventInvocation(MethodBody body, Collection<Instruction> instructions, int index, PropertyDefinition propertyDefinition)
+    {
+        var invokerType = typeNode.EventInvoker.InvokerType;
+        return invokerType switch
         {
-            // always work with start index because instructions shifted when removed
-            targetInstructions.Add(instructions[start]);
-            instructions.RemoveAt(start);
+            InvokerTypes.String                   => InvokeSimple(instructions, index, propertyDefinition),
+            InvokerTypes.BeforeAfter              => InvokeBeforeAfter(body, instructions, index, propertyDefinition, weaver.TypeSystem.ObjectReference),
+            InvokerTypes.BeforeAfterGeneric       => InvokeBeforeAfter(body, instructions, index, propertyDefinition, propertyDefinition.PropertyType),
+            InvokerTypes.PropertyChangedArg       => InvokePropertyChangedArg(instructions, index, propertyDefinition),
+            InvokerTypes.SenderPropertyChangedArg => InvokeSenderPropertyChangedArg(instructions, index, propertyDefinition),
+            _                                     => throw new ArgumentOutOfRangeException($"Unsupported invoker type: {invokerType} for {typeNode.TypeDefinition.FullName}")
+        };
+    }
+
+    int InvokeSimple(Collection<Instruction> instructions, int index, PropertyDefinition property)
+    {
+        ++index; // just skip stfld because we don't need the value
+        index = instructions.Insert(index,
+            Instruction.Create(OpCodes.Ldarg_0),
+            Instruction.Create(OpCodes.Ldstr, property.Name));
+
+        return instructions.Insert(index, PropertyWeaver.CallEventInvoker(typeNode, property.PropertyType).ToArray());
+    }
+
+    int InvokeBeforeAfter(MethodBody body, Collection<Instruction> instructions, int index, PropertyDefinition property, TypeReference argType)
+    {
+        body.InitLocals = true;
+        
+        // store value to temp variable
+        var valueType = property.PropertyType;
+        index = instructions.InsertStoreAndLoadVariable(index, valueType, out var valueVariable);
+        body.Variables.Add(valueVariable);
+        
+        ++index; // skip store field operation which will store temp value to the field
+        
+        VariableDefinition defaultValue = null;                                                                                   // OnPropertyChanged(
+        instructions.Insert(index++, Instruction.Create(OpCodes.Ldarg_0));                                                        //   this
+        instructions.Insert(index++, Instruction.Create(OpCodes.Ldstr, property.Name));                                           //  ,propertyName
+        index = instructions.InsertDefault(index, argType, ref defaultValue);                                                     //  ,default
+        instructions.Insert(index++, Instruction.Create(OpCodes.Ldloc, valueVariable));                                           //  ,value
+        // ensure value type boxed if needed
+        if (!argType.IsValueType && valueType.IsValueType)
+            instructions.Insert(index++, Instruction.Create(OpCodes.Box, valueType));
+        // in some cases default value may require intermediate local variable
+        if (defaultValue != null)
+            body.Variables.Add(defaultValue);
+
+        return instructions.Insert(index, PropertyWeaver.CallEventInvoker(typeNode, argType).ToArray());                        // )
+    }
+
+    int InvokePropertyChangedArg(Collection<Instruction> instructions, int index, PropertyDefinition property)
+    {
+        ++index; // just skip stfld because we don't need the value
+        index = instructions.Insert(index,
+            Instruction.Create(OpCodes.Ldarg_0),
+            Instruction.Create(OpCodes.Ldsfld, weaver.EventArgsCache.GetEventArgsField(property.Name)));
+
+        return instructions.Insert(index, PropertyWeaver.CallEventInvoker(typeNode, property.PropertyType).ToArray());
+    }
+
+    int InvokeSenderPropertyChangedArg(Collection<Instruction> instructions, int index, PropertyDefinition property)
+    {
+        ++index; // just skip stfld because we don't need the value
+        index = instructions.Insert(index,
+            Instruction.Create(OpCodes.Ldarg_0),
+            Instruction.Create(OpCodes.Ldarg_0),
+            Instruction.Create(OpCodes.Ldsfld, weaver.EventArgsCache.GetEventArgsField(property.Name)));
+
+        return instructions.Insert(index, PropertyWeaver.CallEventInvoker(typeNode, property.PropertyType).ToArray());
+    }
+
+    /// <summary>Returns matching property definition for backing field.</summary>
+    bool TryGetNotifyProperty(FieldReference field, out PropertyDefinition property)
+    {
+        property = null;
+        if (!field.IsBackingField()) // only care about backing fields 
+            return false;
+        
+        var mapping = typeNode.Mappings.FirstOrDefault(m => m.FieldDefinition == field);
+        if (mapping is not { PropertyDefinition: var propertyDefinition })
+            return false;
+        
+        // it should be either property in PropertyDatas or explicit notify property
+        if (!typeNode.PropertyDatas.ContainsKey(propertyDefinition) && !(typeNode.ExplicitNotifyProperties?.Contains(propertyDefinition)).GetValueOrDefault()) 
+            return false;
+        
+        property = propertyDefinition;
+        return true;
+    }
+    
+    /// <summary>Moves field assignment to <paramref name="insertIndex"/> which should be greater than <paramref name="fieldAssignmentEnd"/>.</summary>
+    void MoveFieldAssignment(Collection<Instruction> instructions, int insertIndex, int fieldAssignmentStart, int fieldAssignmentEnd)
+    {
+        --insertIndex;                                                            // we remove first, so need to adjust insert index 
+        for (var index = fieldAssignmentStart; index <= fieldAssignmentEnd; ++index)
+        {
+            var instruction = instructions[fieldAssignmentStart]; // always work with start index because instructions shifted when removed
+            instructions.RemoveAt(fieldAssignmentStart);                          
+            instructions.Insert(insertIndex, instruction);        // always insert at same index because all instructions shifted left when instruction removed
         }
     }
 }

--- a/PropertyChanged.Fody/ExplicitNotifyProcessing.cs
+++ b/PropertyChanged.Fody/ExplicitNotifyProcessing.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Mono.Cecil;
 
 public partial class ModuleWeaver
 {
@@ -8,7 +9,7 @@ public partial class ModuleWeaver
     /// Processes all type nodes and fills <see cref="TypeNode.NoOwnNotifyProperties"/> with properties which shouldn't be notified using configuration rules.
     /// If `OnlyNotifyWithAttributes="attr_type_name1,attr_type_name2"` set in the config then all properties without one of listed attributes will be added to NoOwnNotifyProperties and won't emit PropertyChanged event.
     /// </summary>
-    void ProcessNoOwnNotify()
+    void ProcessExplicitNotify()
     {
         HashSet<string> onlyNotifyWithAttributes = null;                                                   // set of full attribute names for which PropertyChanged event should be emitted, if empty then no filtering applied
         var value = Config?.Attributes("OnlyNotifyWithAttributes").Select(x => x.Value).SingleOrDefault(); // check XML config for OnlyNotifyWithAttributes attribute in form of `attr_type_name1,attr_type_name2` (type name with namespace)
@@ -16,20 +17,23 @@ public partial class ModuleWeaver
             onlyNotifyWithAttributes = new HashSet<string>(value.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()));
 
         if (onlyNotifyWithAttributes == null || onlyNotifyWithAttributes.Count == 0) return;               // skip processing if there no attributes specified
-        ProcessNoOwnNotify(NotifyNodes, onlyNotifyWithAttributes);                                         // go recursively through all type nodes and fill NoOwnNotifyProperties
+        ProcessExplicitNotify(NotifyNodes, onlyNotifyWithAttributes);                                      // go recursively through all type nodes and fill NoOwnNotifyProperties
     }
 
     /// <summary>Processes all type nodes and fills <see cref="TypeNode.NoOwnNotifyProperties"/> with properties which doesn't have one of attributes from <paramref name="onlyNotifyWithAttributes"/> set.</summary>
-    void ProcessNoOwnNotify(IEnumerable<TypeNode> nodes, HashSet<string> onlyNotifyWithAttributes)
+    void ProcessExplicitNotify(IEnumerable<TypeNode> nodes, HashSet<string> onlyNotifyWithAttributes)
     {
         foreach (var typeNode in nodes)
         {
+            var explicitNotifyProperties = new HashSet<PropertyDefinition>();
             foreach (var property in typeNode.TypeDefinition.Properties)                                   // go through type properties
             {
-                if (!onlyNotifyWithAttributes.Overlaps(property.CustomAttributes.Names()))                 // check if at least one of custom attributes is in the list
-                    typeNode.NoOwnNotifyProperties.Add(property);                                          // if not so then add property to NoOwnNotifyProperties
+                if (onlyNotifyWithAttributes.Overlaps(property.CustomAttributes.Names()))                  // check if at least one of custom attributes is in the list
+                    explicitNotifyProperties.Add(property);                                                // if not so then add property to NoOwnNotifyProperties
             }
-            ProcessNoOwnNotify(typeNode.Nodes, onlyNotifyWithAttributes);                                  // call recursively for nested type nodes
+
+            typeNode.ExplicitNotifyProperties = explicitNotifyProperties;
+            ProcessExplicitNotify(typeNode.Nodes, onlyNotifyWithAttributes);                               // call recursively for nested type nodes
         }
     }
 }

--- a/PropertyChanged.Fody/InstructionListExtensions.cs
+++ b/PropertyChanged.Fody/InstructionListExtensions.cs
@@ -46,6 +46,15 @@ public static class InstructionListExtensions
         return index;
     }
 
+    /// <summary>Shortcut for Stloc and Ldloc opcodes with new variable creation.</summary>
+    public static int InsertStoreAndLoadVariable(this Collection<Instruction> collection, int index, TypeReference variableType, out VariableDefinition variable)
+    {
+        variable = new VariableDefinition(variableType);
+        collection.Insert(index++, Instruction.Create(OpCodes.Stloc, variable));
+        collection.Insert(index++, Instruction.Create(OpCodes.Ldloc, variable));
+        return index;
+    }
+
     /// <summary>
     /// Inserts default value of <paramref name="valueType"/> at <paramref name="index"/> and returns first index after last inserted instruction (only works with struct types, should be used via <see cref="InsertDefault"/>).
     /// If <paramref name="valueType"/> is non-primitive value type then <paramref name="variable"/> will be either created and initialized or reused if already exists. If you need to insert multiple values of same type then you can reuse variable.

--- a/PropertyChanged.Fody/MappingFinder.cs
+++ b/PropertyChanged.Fody/MappingFinder.cs
@@ -31,7 +31,7 @@ public partial class ModuleWeaver
     static FieldDefinition TryGetField(TypeDefinition typeDefinition, PropertyDefinition property)
     {
         var propertyName = property.Name;
-        var fieldsWithSameType = typeDefinition.Fields.Where(x => x.DeclaringType == typeDefinition && x.FieldType == property.PropertyType).ToList();
+        var fieldsWithSameType = typeDefinition.Fields.Where(x => x.DeclaringType == typeDefinition && x.FieldType.Resolve() == property.PropertyType.Resolve()).ToList();
         foreach (var field in fieldsWithSameType)
         {
             //AutoProp

--- a/PropertyChanged.Fody/ModuleWeaver.cs
+++ b/PropertyChanged.Fody/ModuleWeaver.cs
@@ -29,7 +29,7 @@ public partial class ModuleWeaver: BaseModuleWeaver
         DetectIlGeneratedByDependency();
         ProcessDependsOnAttributes();
         WalkPropertyData();
-        ProcessNoOwnNotify();
+        ProcessExplicitNotify();
         CheckForWarnings();
         ProcessOnChangedMethods();
         CheckForStackOverflow();

--- a/PropertyChanged.Fody/TypeNode.cs
+++ b/PropertyChanged.Fody/TypeNode.cs
@@ -6,22 +6,21 @@ public class TypeNode
 {
     public TypeNode()
     {
-        Nodes = new List<TypeNode>();
-        PropertyDependencies = new List<PropertyDependency>();
-        Mappings = new List<MemberMapping>();
-        PropertyDatas = new Dictionary<PropertyDefinition, PropertyData>();
-        NoOwnNotifyProperties = new HashSet<PropertyDefinition>();
+        Nodes                 = new List<TypeNode>();
+        PropertyDependencies  = new List<PropertyDependency>();
+        Mappings              = new List<MemberMapping>();
+        PropertyDatas         = new Dictionary<PropertyDefinition, PropertyData>();
     }
 
-    public TypeDefinition TypeDefinition;
-    public List<TypeNode> Nodes;
-    public List<PropertyDependency> PropertyDependencies;
-    public List<MemberMapping> Mappings;
-    public EventInvokerMethod EventInvoker;
-    public MethodReference IsChangedInvoker;
+    public TypeDefinition                               TypeDefinition;
+    public List<TypeNode>                               Nodes;
+    public List<PropertyDependency>                     PropertyDependencies;
+    public List<MemberMapping>                          Mappings;
+    public EventInvokerMethod                           EventInvoker;
+    public MethodReference                              IsChangedInvoker;
     public Dictionary<PropertyDefinition, PropertyData> PropertyDatas;
-    public List<PropertyDefinition> AllProperties;
-    public ICollection<OnChangedMethod> OnChangedMethods;
-    public HashSet<PropertyDefinition> NoOwnNotifyProperties; // these properties won't emit PropertyChanged event, but still may notify dependent properties or invoke on change methods
+    public List<PropertyDefinition>                     AllProperties;
+    public ICollection<OnChangedMethod>                 OnChangedMethods;
+    public HashSet<PropertyDefinition>                  ExplicitNotifyProperties; // set of explicit notify properties, may be restricted with only notify property attributes 
     public IEnumerable<PropertyDefinition> DeclaredProperties => AllProperties.Where(prop => prop.DeclaringType == TypeDefinition);
 }

--- a/PropertyChanged.Fody/TypeProcessor.cs
+++ b/PropertyChanged.Fody/TypeProcessor.cs
@@ -20,7 +20,7 @@ public partial class ModuleWeaver
 
             WriteDebug("\t" + node.TypeDefinition.FullName);
             
-            new ConstructorWeaver(node).Execute();
+            new ConstructorWeaver(this, node).Execute();
             
             foreach (var propertyData in node.PropertyDatas.Values)
             {

--- a/TestAssemblies/AssemblyToProcess/WithInitializedProperties/ClassWithInlineInitializedAutoProperties.cs
+++ b/TestAssemblies/AssemblyToProcess/WithInitializedProperties/ClassWithInlineInitializedAutoProperties.cs
@@ -6,7 +6,9 @@ public class ClassWithInlineInitializedAutoProperties : ObservableTestObject
 
     public string Property2 { get; set; } = "Test2";
 
-    public List<string> Property3 { get; set; } = new(); 
+    public List<string> Property3 { get; set; } = new();
 
+    public List<string> Property4 { get; } = new();
+    
     public bool IsChanged { get; set; }
 }

--- a/TestAssemblies/AssemblyToProcess/WithInitializedProperties/ClassWithInlineInitializedAutoProperties.cs
+++ b/TestAssemblies/AssemblyToProcess/WithInitializedProperties/ClassWithInlineInitializedAutoProperties.cs
@@ -1,8 +1,12 @@
+using System.Collections.Generic;
+
 public class ClassWithInlineInitializedAutoProperties : ObservableTestObject
 {
     public string Property1 { get; set; } = "Test";
 
     public string Property2 { get; set; } = "Test2";
+
+    public List<string> Property3 { get; set; } = new(); 
 
     public bool IsChanged { get; set; }
 }

--- a/TestAssemblies/AssemblyWithPropertyAttributes/ClassBeforeAfterGenericWithAttributedProperties.cs
+++ b/TestAssemblies/AssemblyWithPropertyAttributes/ClassBeforeAfterGenericWithAttributedProperties.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using PropertyChanged;
+
+/// <summary>Test class for processors working with property attributes (i.e. NoOwnNotifyProcessing).</summary>
+public class ClassBeforeAfterGenericWithAttributedProperties : INotifyPropertyChanged
+{
+    public List<string>                       Notifications = new();
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    [DisplayName]                        public string? DisplayName             { get; set; }
+    [Description]                        public string? Description             { get; set; }
+    [AlsoNotifyFor(nameof(DisplayName))] public string? NoOwnNotify             { get; set; }
+    [DisplayName]                        public string? DisplayNameAuto         { get; set; } = "Auto";
+    public                                      string? NoOwnNotifyAuto         { get; set; } = "Auto";
+    [DisplayName] public                        int     DisplayNameAutoReadOnly { get; }      = 42;
+    public                                      int     NoOwnNotifyAutoReadOnly { get; }      = 42;
+
+    public void OnNoOwnNotifyChanged() => Notifications.Add("method:NoOwnNotify");
+
+    void OnPropertyChanged<T>(string name, T before, T after) => Notifications.Add($"event:{name}:{before}:{after}");
+}

--- a/TestAssemblies/AssemblyWithPropertyAttributes/ClassBeforeAfterWithAttributedProperties.cs
+++ b/TestAssemblies/AssemblyWithPropertyAttributes/ClassBeforeAfterWithAttributedProperties.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using PropertyChanged;
+
+/// <summary>Test class for processors working with property attributes (i.e. NoOwnNotifyProcessing).</summary>
+public class ClassBeforeAfterWithAttributedProperties : INotifyPropertyChanged
+{
+    public List<string>                       Notifications = new();
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    [DisplayName]                        public string? DisplayName             { get; set; }
+    [Description]                        public string? Description             { get; set; }
+    [AlsoNotifyFor(nameof(DisplayName))] public string? NoOwnNotify             { get; set; }
+    [DisplayName]                        public string? DisplayNameAuto         { get; set; } = "Auto";
+    public                                      string? NoOwnNotifyAuto         { get; set; } = "Auto";
+    [DisplayName] public                        int     DisplayNameAutoReadOnly { get; }      = 42;
+    public                                      int     NoOwnNotifyAutoReadOnly { get; }      = 42;
+
+    public void OnNoOwnNotifyChanged() => Notifications.Add("method:NoOwnNotify");
+
+    void OnPropertyChanged(string name, object before, object after) => Notifications.Add($"event:{name}:{before}:{after}");
+}

--- a/TestAssemblies/AssemblyWithPropertyAttributes/ClassPropertyChangedArgWithAttributedProperties.cs
+++ b/TestAssemblies/AssemblyWithPropertyAttributes/ClassPropertyChangedArgWithAttributedProperties.cs
@@ -4,11 +4,10 @@ using System.ComponentModel;
 using PropertyChanged;
 
 /// <summary>Test class for processors working with property attributes (i.e. NoOwnNotifyProcessing).</summary>
-public class ClassWithAttributedProperties : INotifyPropertyChanged
+public class ClassPropertyChangedArgWithAttributedProperties : INotifyPropertyChanged
 {
-    public List<string>                       Notifications   = new List<string>();
+    public List<string>                       Notifications = new();
     public event PropertyChangedEventHandler? PropertyChanged;
-
 
     [DisplayName]                        public string?  DisplayName             { get; set; }
     [Description]                        public string?  Description             { get; set; }
@@ -20,5 +19,5 @@ public class ClassWithAttributedProperties : INotifyPropertyChanged
 
     public void OnNoOwnNotifyChanged() => Notifications.Add("method:NoOwnNotify");
 
-    void OnPropertyChanged(string name) => Notifications.Add($"event:{name}");
+    void OnPropertyChanged(PropertyChangedEventArgs args) => Notifications.Add($"event:{args.PropertyName}");
 }

--- a/TestAssemblies/AssemblyWithPropertyAttributes/ClassSenderPropertyChangedArgWithAttributedProperties.cs
+++ b/TestAssemblies/AssemblyWithPropertyAttributes/ClassSenderPropertyChangedArgWithAttributedProperties.cs
@@ -4,11 +4,10 @@ using System.ComponentModel;
 using PropertyChanged;
 
 /// <summary>Test class for processors working with property attributes (i.e. NoOwnNotifyProcessing).</summary>
-public class ClassWithAttributedProperties : INotifyPropertyChanged
+public class ClassSenderPropertyChangedArgWithAttributedProperties : INotifyPropertyChanged
 {
-    public List<string>                       Notifications   = new List<string>();
+    public List<string>                       Notifications = new();
     public event PropertyChangedEventHandler? PropertyChanged;
-
 
     [DisplayName]                        public string?  DisplayName             { get; set; }
     [Description]                        public string?  Description             { get; set; }
@@ -20,5 +19,5 @@ public class ClassWithAttributedProperties : INotifyPropertyChanged
 
     public void OnNoOwnNotifyChanged() => Notifications.Add("method:NoOwnNotify");
 
-    void OnPropertyChanged(string name) => Notifications.Add($"event:{name}");
+    void OnPropertyChanged(object sender, PropertyChangedEventArgs args) => Notifications.Add($"event:{args.PropertyName}");
 }

--- a/Tests/AssemblyToProcessTests.cs
+++ b/Tests/AssemblyToProcessTests.cs
@@ -35,7 +35,7 @@ public class AssemblyToProcessTests
 
     [Theory]
     [InlineData("ClassWithInlineInitializedAutoProperties",
-        "Test", "Test2", true, new[] { "IsChanged", "Property1", "Property2" })]
+        "Test", "Test2", true, new[] { "IsChanged", "Property1", "Property2", "Property3" })]
     [InlineData("ClassWithInlineInitializedAutoPropertiesWithoutBase",
         "Test", "Test2", true, new[] { "IsChanged", "Property1", "Property2" })]
     [InlineData("ClassWithExplicitInitializedAutoProperties",
@@ -64,7 +64,7 @@ public class AssemblyToProcessTests
         var actualPropertyChangedCalls = (IList<string>)instance.PropertyChangedCalls;
         Debug.WriteLine("PropertyChanged calls: " + string.Join(", ", actualPropertyChangedCalls));
 
-        Assert.True(propertyChangedCallsInConstructor.SequenceEqual(actualPropertyChangedCalls));
+        Assert.Equal(propertyChangedCallsInConstructor, actualPropertyChangedCalls);
         Assert.Equal(isChangedStateAfterConstructor, instance.IsChanged);
 
         var initial = isChangedStateAfterConstructor ? 1 : 2;

--- a/Tests/CheckForNoOwnNotifyPropertiesTests.cs
+++ b/Tests/CheckForNoOwnNotifyPropertiesTests.cs
@@ -3,18 +3,30 @@ using System.Xml.Linq;
 using Fody;
 using Xunit;
 
-public class NoOwnNotifyProcessingTests
+public class ExplicitNotifyProcessingTests
 {
     [Theory]
-    [InlineData("System.ComponentModel.DisplayNameAttribute", new[] { "event:DisplayName", "event:DisplayName", "method:NoOwnNotify" })]
-    [InlineData("System.ComponentModel.DescriptionAttribute", new[] { "event:Description", "method:NoOwnNotify" })]
-    [InlineData("System.ComponentModel.DisplayNameAttribute,System.ComponentModel.DescriptionAttribute", new[] { "event:DisplayName", "event:Description", "event:DisplayName", "method:NoOwnNotify" })]
-    public void OnlyNotifiesPropertiesWithDisplayNameAttribute(string onlyNotifyWithAttributes, string[] expectedNotifications)
+    [InlineData("ClassWithAttributedProperties",                         "System.ComponentModel.DisplayNameAttribute",                                            new[] { "event:DisplayNameAuto", "event:DisplayNameAutoReadOnly", "event:DisplayName", "event:DisplayName", "method:NoOwnNotify" })]
+    [InlineData("ClassWithAttributedProperties",                         "System.ComponentModel.DescriptionAttribute",                                            new[] { "event:Description", "method:NoOwnNotify" })]
+    [InlineData("ClassWithAttributedProperties",                         "System.ComponentModel.DisplayNameAttribute,System.ComponentModel.DescriptionAttribute", new[] { "event:DisplayNameAuto", "event:DisplayNameAutoReadOnly", "event:DisplayName", "event:Description", "event:DisplayName", "method:NoOwnNotify" })]
+    [InlineData("ClassSenderPropertyChangedArgWithAttributedProperties", "System.ComponentModel.DisplayNameAttribute",                                            new[] { "event:DisplayNameAuto", "event:DisplayNameAutoReadOnly", "event:DisplayName", "event:DisplayName", "method:NoOwnNotify" })]
+    [InlineData("ClassSenderPropertyChangedArgWithAttributedProperties", "System.ComponentModel.DescriptionAttribute",                                            new[] { "event:Description", "method:NoOwnNotify" })]
+    [InlineData("ClassSenderPropertyChangedArgWithAttributedProperties", "System.ComponentModel.DisplayNameAttribute,System.ComponentModel.DescriptionAttribute", new[] { "event:DisplayNameAuto", "event:DisplayNameAutoReadOnly", "event:DisplayName", "event:Description", "event:DisplayName", "method:NoOwnNotify" })]
+    [InlineData("ClassPropertyChangedArgWithAttributedProperties",       "System.ComponentModel.DisplayNameAttribute",                                            new[] { "event:DisplayNameAuto", "event:DisplayNameAutoReadOnly", "event:DisplayName", "event:DisplayName", "method:NoOwnNotify" })]
+    [InlineData("ClassPropertyChangedArgWithAttributedProperties",       "System.ComponentModel.DescriptionAttribute",                                            new[] { "event:Description", "method:NoOwnNotify" })]
+    [InlineData("ClassPropertyChangedArgWithAttributedProperties",       "System.ComponentModel.DisplayNameAttribute,System.ComponentModel.DescriptionAttribute", new[] { "event:DisplayNameAuto", "event:DisplayNameAutoReadOnly", "event:DisplayName", "event:Description", "event:DisplayName", "method:NoOwnNotify" })]
+    [InlineData("ClassBeforeAfterWithAttributedProperties",              "System.ComponentModel.DisplayNameAttribute",                                            new[] { "event:DisplayNameAuto::Auto", "event:DisplayNameAutoReadOnly::42", "event:DisplayName::My Name", "event:DisplayName:My Name:My Name", "method:NoOwnNotify" })]
+    [InlineData("ClassBeforeAfterWithAttributedProperties",              "System.ComponentModel.DescriptionAttribute",                                            new[] { "event:Description::My Description", "method:NoOwnNotify" })]
+    [InlineData("ClassBeforeAfterWithAttributedProperties",              "System.ComponentModel.DisplayNameAttribute,System.ComponentModel.DescriptionAttribute", new[] { "event:DisplayNameAuto::Auto", "event:DisplayNameAutoReadOnly::42", "event:DisplayName::My Name", "event:Description::My Description", "event:DisplayName:My Name:My Name", "method:NoOwnNotify" })]
+    [InlineData("ClassBeforeAfterGenericWithAttributedProperties",       "System.ComponentModel.DisplayNameAttribute",                                            new[] { "event:DisplayNameAuto::Auto", "event:DisplayNameAutoReadOnly:0:42", "event:DisplayName::My Name", "event:DisplayName:My Name:My Name", "method:NoOwnNotify" })]
+    [InlineData("ClassBeforeAfterGenericWithAttributedProperties",       "System.ComponentModel.DescriptionAttribute",                                            new[] { "event:Description::My Description", "method:NoOwnNotify" })]
+    [InlineData("ClassBeforeAfterGenericWithAttributedProperties",       "System.ComponentModel.DisplayNameAttribute,System.ComponentModel.DescriptionAttribute", new[] { "event:DisplayNameAuto::Auto", "event:DisplayNameAutoReadOnly:0:42", "event:DisplayName::My Name", "event:Description::My Description", "event:DisplayName:My Name:My Name", "method:NoOwnNotify" })]
+    public void OnlyNotifiesPropertiesWithAttributes(string typeName, string onlyNotifyWithAttributes, string[] expectedNotifications)
     {
         var xElement = XElement.Parse($"<PropertyChanged OnlyNotifyWithAttributes='{onlyNotifyWithAttributes}'/>");
         var moduleWeaver = new ModuleWeaver { Config = xElement };
         var testResult = moduleWeaver.ExecuteTestRun("AssemblyWithPropertyAttributes.dll");
-        var instance = testResult.GetInstance("ClassWithAttributedProperties");
+        var instance = testResult.GetInstance(typeName);
         instance.DisplayName = "My Name";
         instance.Description = "My Description";
         instance.NoOwnNotify = "Value";


### PR DESCRIPTION
1. Fixes issue with notifications for generic auto properties for inline initialization.
2. Adds support for notifications for explicitly marked auto properties for inline initialization.